### PR TITLE
add missing tqdm dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "PyYAML",
         "scikit-learn",
         "xxhash",
+        "tqdm",
     ],
     package_data={"": ["README.md"]},
     classifiers=[


### PR DESCRIPTION
 - it's used in the show_pbar stuff and errors if you don't have it installed already