### PR TITLE
fix default max_epochs causes tqdm error

### DIFF
--- a/fragile/core/base_classes.py
+++ b/fragile/core/base_classes.py
@@ -480,7 +480,7 @@ class BaseWalkers(StatesOwner):
 
         """
         super(BaseWalkers, self).__init__()
-        self.max_epochs = max_epochs if max_epochs is not None else 1e12
+        self.max_epochs = max_epochs if max_epochs is not None else int(1e12)
         self._epoch = 0
         self.n_walkers = n_walkers
         self.id_walkers = None


### PR DESCRIPTION
- turns out that 1e6 is a float, and tqdm doesn't like it. convert the default to int so tqdm is satisfied

To reproduce:
```
import tqdm
tqdm.tqdm(range(1e6))
```