### PR TITLE
Move "plangym" to "atari" extras and lazy load the module

### DIFF
--- a/fragile/core/env.py
+++ b/fragile/core/env.py
@@ -2,7 +2,6 @@ import copy
 from typing import Dict, Union
 
 import numpy
-from plangym.core import GymEnvironment as PlangymEnvironment
 
 from fragile.core.base_classes import BaseEnvironment
 from fragile.core.states import StateDict, StatesEnv, StatesModel
@@ -86,7 +85,7 @@ class DiscreteEnv(Environment):
     follows the interface of `plangym`.
     """
 
-    def __init__(self, env: PlangymEnvironment):
+    def __init__(self, env: "plangym.core.GymEnvironment"):
         """
         Initialize a :class:`DiscreteEnv`.
 

--- a/fragile/core/utils.py
+++ b/fragile/core/utils.py
@@ -1,7 +1,6 @@
 from typing import Any, Callable, Dict, Generator, Tuple, Union
 
 import numpy
-from plangym import BaseEnvironment as PlangymEnv, ParallelEnvironment as PlangymParallelEnv
 import xxhash
 
 
@@ -32,8 +31,12 @@ def running_in_ipython() -> bool:
         return False
 
 
-def get_plangym_env(swarm: "Swarm") -> PlangymEnv:  # noqa: F821
+def get_plangym_env(swarm: "Swarm") -> "plangym.BaseEnvironment":  # noqa: F821
     """Return the :class:`plangym.Environment` of the target Swarm."""
+    from plangym import (
+        BaseEnvironment as PlangymEnv,
+        ParallelEnvironment as PlangymParallelEnv,
+    )
     from fragile import core
     from fragile.distributed import ParallelEnv as FragileParallelEnv, RayEnv
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(Path(__file__).with_name("README.md"), encoding="utf-8") as f:
 
 # Module-specific dependencies.
 extras = {
-    "atari": ["atari-py==0.1.1", "opencv-python", "gym", "pillow-simd"],
+    "atari": ["atari-py==0.1.1", "opencv-python", "gym", "pillow-simd", "plangym>=0.0.7"],
     "dataviz": [
         "matplotlib",
         "bokeh<2.0.0",
@@ -49,16 +49,7 @@ setup(
     keywords=["reinforcement learning", "artificial intelligence", "monte carlo", "planning"],
     tests_require=["pytest>=5.3.5", "hypothesis>=5.6.0"],
     extras_require=extras,
-    install_requires=[
-        "networkx",
-        "numba",
-        "numpy",
-        "scipy",
-        "plangym>=0.0.7",
-        "PyYAML",
-        "xxhash",
-        "tqdm",
-    ],
+    install_requires=["networkx", "numba", "numpy", "scipy", "PyYAML", "xxhash", "tqdm"],
     package_data={"": ["README.md"]},
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
 - mathy is still pulling `pillow-simd` by way of `plangym`, which fails on most OSX setups
 - move plangym dependency from the main library to "atari" (is that enough, or should it go in the other extras as well?)
 - update `utils.py` to delay importing plangym until `get_plangym_env` is called
 - update `env.py` to use a string wrapper type for plangym envs instead of importing the module itself.