### PR TITLE
delay loading the ray module until `RayEnv` is used

### DIFF
--- a/fragile/distributed/env.py
+++ b/fragile/distributed/env.py
@@ -10,8 +10,6 @@ from fragile.core.env import Environment as CoreEnv
 from fragile.core.states import StatesEnv, StatesModel
 from fragile.core.utils import split_args_in_chunks, split_kwargs_in_chunks
 from fragile.core.wrappers import BaseWrapper, EnvWrapper
-from fragile.distributed.ray import ray
-from fragile.distributed.ray.env import Environment as RemoteEnvironment
 
 
 class _ExternalProcess:
@@ -443,6 +441,8 @@ class RayEnv(EnvWrapper):
             env_kwargs: Passed to ``env_callable``.
 
         """
+        from fragile.distributed.ray.env import Environment as RemoteEnvironment
+
         env_kwargs = {} if env_kwargs is None else env_kwargs
         self.n_workers = n_workers
         self.envs: List[RemoteEnvironment] = [
@@ -523,6 +523,8 @@ class RayEnv(EnvWrapper):
             return split_args_in_chunks(args, len(self.envs))
 
     def _make_transitions(self, split_results):
+        from fragile.distributed.ray import ray
+
         results = [
             env.make_transitions.remote(**chunk)
             if self.kwargs_mode
@@ -552,6 +554,8 @@ class RayEnv(EnvWrapper):
             batch_size.
 
         """
+        from fragile.distributed.ray import ray
+
         reset = [
             env.reset.remote(batch_size=batch_size, env_states=env_states, *args, **kwargs)
             for env in self.envs


### PR DESCRIPTION
 - the same thing happens that did with plangym. the module gets imported when you only try to import "fragile.distributed.env.ParallelEnv"