### PR TITLE
Add __call__ to base classes

### DIFF
--- a/fragile/core/base_classes.py
+++ b/fragile/core/base_classes.py
@@ -75,6 +75,18 @@ class BaseTree:
         """
         self.root_id = root_id
 
+    def __call__(self, *args, **kwargs) -> "BaseTree":
+        """
+        Return the current instance of :class:`BaseTree`.
+
+        This is used to avoid defining a ``tree_callable `` as \
+        ``lambda: tree_instance`` when initializing a :class:`Swarm`. If the \
+        :class:`BaseTree` needs is passed to a remote process, you may need \
+        to write custom serialization for it, or resort to creating an appropriate \
+        ``tree_callable``.
+        """
+        return self
+
     def add_states(
         self,
         parent_ids: List[int],
@@ -239,6 +251,18 @@ class BaseEnvironment(StatesOwner):
 
     STATE_CLASS = StatesEnv
 
+    def __call__(self, *args, **kwargs) -> "BaseEnvironment":
+        """
+        Return the current instance of :class:`BaseEnvironment`.
+
+        This is used to avoid defining a ``environment_callable `` as \
+        ``lambda: environment_instance`` when initializing a :class:`Swarm`. If the \
+        :class:`Environment` needs is passed to a remote process, you may need \
+        to write custom serialization for it, or resort to creating an appropriate \
+        ``environment_callable``.
+        """
+        return self
+
     def step(self, model_states: StatesModel, env_states: StatesEnv) -> StatesEnv:
         """
         Step the environment for a batch of walkers.
@@ -378,6 +402,18 @@ class BaseModel(StatesOwner):
 
     STATE_CLASS = StatesModel
 
+    def __call__(self, *args, **kwargs) -> "BaseModel":
+        """
+        Return the current instance of :class:`BaseModel`.
+
+        This is used to avoid defining a ``model_callable `` as \
+        ``lambda: model_instance`` when initializing a :class:`Swarm`. If a \
+        :class:`Model` is passed to a remote process, you may need to write custom \
+        serialization for it, or resort to creating an appropriate \
+        ``model_callable``.
+        """
+        return self
+
     def get_params_dict(self) -> StateDict:
         """
         Return an state_dict to be used for instantiating the states containing \
@@ -488,6 +524,18 @@ class BaseWalkers(StatesOwner):
         self._accumulate_rewards = accumulate_rewards
         self.env_states_params = env_state_params
         self.model_states_params = model_state_params
+
+    def __call__(self, *args, **kwargs) -> "BaseWalkers":
+        """
+        Return the current instance of :class:`BaseWalkers`.
+
+        This is used to avoid defining a ``walkers_callable `` as \
+        ``lambda: walkers_instance`` when initializing a :class:`Swarm`. If the \
+        :class:`Walkers` needs is passed to a remote process, you may need \
+        to write custom serialization for it, or resort to creating an appropriate \
+        ``walkers_callable``.
+        """
+        return self
 
     def __len__(self) -> int:
         """Return length is the number of walkers."""


### PR DESCRIPTION
This avoids creating boilerplate lambdas when they are not necessary to avoid custom serialization code.

Thanks to @justindujardin  for making me notice that this can save some headaches https://github.com/justindujardin/mathy/issues/36