### PR TITLE
Clarify beta function remark in binding field documentation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,3 +1,4 @@
 # Authors
 
 * Guillem Duran Ballester - fragile.tech
+* OpenAI - openai.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+Unreleased
+----------
+
+* Clarify the binding-field remark on beta-function sign dependence and confinement justification.
 
 0.2.0 (2024-10-10)
 ------------------

--- a/docs/source/1_agent/08_multiagent/02_standard_model.md
+++ b/docs/source/1_agent/08_multiagent/02_standard_model.md
@@ -461,7 +461,13 @@ where $f^{abc}$ are the structure constants of $SU(N_f)$, defined by $[\lambda^a
 
 - **Infrared Confinement:** At large distances (low RG scale, coarse representations), the effective coupling grows. Features cannot propagate independently; they form bound states (concepts $K$).
 
-*Remark:* The asymptotic freedom property holds for all $SU(N_f)$ gauge theories with $N_f \geq 2$. The confinement scale depends on $N_f$ but the qualitative behavior is universal.
+*Remark:* The sign of the beta function is not universal for all gauge theories; it depends on the matter
+content and representations coupled to the field. In the Fragile Mechanics binding sector postulated
+here, the gauge field couples to the cognitive spinor (fundamental "color" index) while the ontological
+scalar is color-neutral as written. With only $O(1)$ fundamental fermion species, the one-loop
+coefficient is in the asymptotically-free regime, so $\beta(g_s) < 0$ at weak coupling. Confinement/binding
+at coarse scales is then justified by the Area-Law/observability result (Theorem {prf:ref}`thm-fission-inhibition`
+/ Section 33), rather than asserted as a universal consequence of $SU(N_f)$ alone.
 
 **Step 4.** From Theorem {prf:ref}`thm-fission-inhibition`, the energy cost of separating features grows linearly with distance (Area Law, {ref}`Section 33 <sec-causal-information-bound>`). Attempting to isolate a feature instead triggers Ontological Fission (Definition {prf:ref}`def-query-fission`), creating new concept pairs.
 

--- a/docs/source/1_agent/reference.md
+++ b/docs/source/1_agent/reference.md
@@ -7394,7 +7394,13 @@ where $f^{abc}$ are the structure constants of $SU(N_f)$, defined by $[\lambda^a
 
 - **Infrared Confinement:** At large distances (low RG scale, coarse representations), the effective coupling grows. Features cannot propagate independently; they form bound states (concepts $K$).
 
-*Remark:* The asymptotic freedom property holds for all $SU(N_f)$ gauge theories with $N_f \geq 2$. The confinement scale depends on $N_f$ but the qualitative behavior is universal.
+*Remark:* The sign of the beta function is not universal for all gauge theories; it depends on the matter
+content and representations coupled to the field. In the Fragile Mechanics binding sector postulated
+here, the gauge field couples to the cognitive spinor (fundamental "color" index) while the ontological
+scalar is color-neutral as written. With only $O(1)$ fundamental fermion species, the one-loop
+coefficient is in the asymptotically-free regime, so $\beta(g_s) < 0$ at weak coupling. Confinement/binding
+at coarse scales is then justified by the Area-Law/observability result (Theorem {prf:ref}`thm-fission-inhibition`
+/ Section 33), rather than asserted as a universal consequence of $SU(N_f)$ alone.
 
 **Step 4.** From Theorem {prf:ref}`thm-fission-inhibition`, the energy cost of separating features grows linearly with distance (Area Law, {ref}`Section 33 <sec-causal-information-bound>`). Attempting to isolate a feature instead triggers Ontological Fission (Definition {prf:ref}`def-query-fission`), creating new concept pairs.
 


### PR DESCRIPTION
This commit clarifies the remark on the beta function sign in the binding
field theorem. The previous statement incorrectly implied that asymptotic
freedom is universal for all SU(N_f) gauge theories. The updated remark
properly explains that the beta function sign depends on matter content
and representations, and references the Area-Law/observability result
(Theorem thm-fission-inhibition) as the justification for confinement.

Changes:
- Updated remark in docs/source/1_agent/08_multiagent/02_standard_model.md
- Updated corresponding section in docs/source/1_agent/reference.md
- Added OpenAI to AUTHORS.md
- Updated CHANGELOG.md with unreleased entry