### PR TITLE
Fix critical documentation build errors

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -95,7 +95,7 @@ Standard RL appears as a degenerate limit of the Fragile Agent when geometry is 
 - **Causal Information Bound** (area law for representational capacity) ({ref}`Section 33 <sec-causal-information-bound>`)
 - **Standard Model of Cognition** and gauge-theoretic unification ({ref}`Section 34 <sec-standard-model-cognition>`)
 - **Parameter Space Sieve** deriving fundamental constants ({ref}`Section 35 <sec-parameter-space-sieve>`)
-- **Economic applications** via Partially Observable Markov Wealth ({ref}`Part IX <sec-pomw>`)
+- **Economic applications** via Partially Observable Markov Wealth ({ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`)
 - **Proof of Useful Work** consensus replacing hash mining with gradient computation ({ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`)
 
 **Proof of Useful Work (PoUW) — Key Security Properties:**
@@ -121,7 +121,7 @@ The economic layer introduces a novel consensus mechanism where the cryptographi
 - *Want limits?* → {ref}`Section 33 <sec-causal-information-bound>`
 - *Want gauge theory?* → {ref}`Section 34 <sec-standard-model-cognition>`
 - *Want fundamental constants?* → {ref}`Section 35 <sec-parameter-space-sieve>`
-- *Want blockchain/economics?* → {ref}`Part IX <sec-pomw>`
+- *Want blockchain/economics?* → {ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`
 - *Want objections answered?* → {ref}`Appendix D <sec-appendix-d-frequently-asked-questions>`
 - *Want proofs?* → {ref}`Appendix A <sec-appendix-a-full-derivations>`
 
@@ -305,9 +305,9 @@ This framework introduces a unified nomenclature. While these terms may seem nov
 12. **Thermodynamic grounding.** Constants like the hysteresis threshold $\epsilon_{\text{hysteresis}}$ are not free parameters but are derived from Landauer thermodynamics ({prf:ref}`thm-thermodynamic-hysteresis-bound`), ensuring ontological operations respect computational metabolism.
 13. **Gauge-theoretic unification.** The three forces governing agent dynamics—value gradient transport, prediction-error correction, and feature binding—are derived as gauge fields from local invariance principles. The symmetry group $G_{\text{Fragile}} = SU(N_f)_C \times SU(2)_L \times U(1)_Y$ emerges from cybernetic first principles ({ref}`Section 34 <sec-standard-model-cognition>`).
 14. **Fundamental constants from constraint satisfaction.** The Agent Parameter Vector $\Lambda = (c_{\text{info}}, \sigma, \ell_L, T_c, g_s, \gamma)$ solves a constrained optimization problem. Sieve constraints (causal, holographic, metabolic, hierarchical, stiffness, temporal) define a feasible region; viable agents operate on its Pareto boundary ({ref}`Section 35 <sec-parameter-space-sieve>`).
-15. **Metabolic transducer architecture.** Energy-information coupling is made explicit through the metabolic transducer, which converts computational resources into information updates while respecting Landauer bounds. This provides principled "thinking fast vs slow" phase transitions ({ref}`Part VII <sec-metabolic-transducer>`).
-16. **Intersubjective metric for shared meaning.** Multi-agent communication is grounded in a shared metric space where meaning emerges from geometric alignment between agents' latent representations, enabling principled analysis of language grounding and semantic drift ({ref}`Part VII <sec-intersubjective-metric>`).
-17. **Economic unification via POMW.** Partially Observable Markov Wealth (POMW) extends the framework to economic agents, treating wealth as a conserved quantity under metabolic constraints and unifying game-theoretic equilibria with the geometric field theory ({ref}`Part IX <sec-pomw>`).
+15. **Metabolic transducer architecture.** Energy-information coupling is made explicit through the metabolic transducer, which converts computational resources into information updates while respecting Landauer bounds. This provides principled "thinking fast vs slow" phase transitions ({ref}`Part VII <sec-the-metabolic-transducer-autopoiesis-and-the-szilard-engine>`).
+16. **Intersubjective metric for shared meaning.** Multi-agent communication is grounded in a shared metric space where meaning emerges from geometric alignment between agents' latent representations, enabling principled analysis of language grounding and semantic drift ({ref}`Part VII <sec-the-inter-subjective-metric-gauge-locking-and-the-emergence-of-objective-reality>`).
+17. **Economic unification via POMW.** Partially Observable Markov Wealth (POMW) extends the framework to economic agents, treating wealth as a conserved quantity under metabolic constraints and unifying game-theoretic equilibria with the geometric field theory ({ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`).
 18. **Proof of Useful Work consensus.** The framework enables a novel blockchain consensus mechanism where hash mining is replaced by gradient computation on a shared neural network. Security is guaranteed by the Landauer bound (thermodynamic hardness), the Sieve constraints (fake gradient detection), and geometric coherence (adversaries are damped, not outvoted). Key theorems: Cognitive Equivalency ({prf:ref}`thm-cognitive-equivalency`), Holographic Verification ({prf:ref}`thm-holographic-verification`), Verifier's Nash Equilibrium ({prf:ref}`thm-verifier-nash-equilibrium`), 51% Attack Rejection ({prf:ref}`thm-51-attack-rejection`), and Adversarial Geometric Damping ({prf:ref}`thm-adversarial-geometric-damping`). The result: energy expenditure produces intelligence instead of heat, and adversaries cannot buy consensus because they cannot buy geometric alignment ({ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`).
 
 (sec-what-is-novel-here-vs-what-is-repackaging)=
@@ -349,12 +349,12 @@ This framework introduces a unified nomenclature. While these terms may seem nov
 
 *Extended Cognitive Architecture:*
 
-18. **Metabolic transducer.** Energy-information coupling is formalized through the metabolic transducer architecture, which converts computational resources into information updates while respecting Landauer bounds. Provides principled "thinking fast vs slow" phase transitions with explicit switching criteria ({ref}`Part VII <sec-metabolic-transducer>`).
-19. **Intersubjective metric.** Multi-agent semantic alignment is grounded in a shared metric space where meaning emerges from geometric alignment between agents' latent representations. Enables principled analysis of language grounding, semantic drift, and communication bandwidth ({ref}`Part VII <sec-intersubjective-metric>`).
+18. **Metabolic transducer.** Energy-information coupling is formalized through the metabolic transducer architecture, which converts computational resources into information updates while respecting Landauer bounds. Provides principled "thinking fast vs slow" phase transitions with explicit switching criteria ({ref}`Part VII <sec-the-metabolic-transducer-autopoiesis-and-the-szilard-engine>`).
+19. **Intersubjective metric.** Multi-agent semantic alignment is grounded in a shared metric space where meaning emerges from geometric alignment between agents' latent representations. Enables principled analysis of language grounding, semantic drift, and communication bandwidth ({ref}`Part VII <sec-the-inter-subjective-metric-gauge-locking-and-the-emergence-of-objective-reality>`).
 
 *Economic Extensions:*
 
-20. **Partially Observable Markov Wealth (POMW).** Economic agents are unified with the geometric field theory by treating wealth as a conserved quantity under metabolic constraints. Game-theoretic equilibria emerge as geometric fixed points; resource allocation follows from holographic interface capacity ({ref}`Part IX <sec-pomw>`).
+20. **Partially Observable Markov Wealth (POMW).** Economic agents are unified with the geometric field theory by treating wealth as a conserved quantity under metabolic constraints. Game-theoretic equilibria emerge as geometric fixed points; resource allocation follows from holographic interface capacity ({ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`).
 21. **Proof of Useful Work (PoUW) consensus.** A novel blockchain consensus mechanism where the cryptographic puzzle is replaced by gradient computation on a shared neural network. Novel contributions include: (a) Cognitive Equivalency Theorem proving gradients have the same thermodynamic hardness as hashes; (b) Holographic Verification reducing verification cost from $O(N)$ to $O(\sqrt{N})$; (c) Verifier's Nash Equilibrium proving honest computation is strictly dominant; (d) Minimum Friction BFT achieving Byzantine tolerance via geometric coherence; (e) 51% Attack Rejection via Spontaneous Fission; (f) Adversarial Geometric Damping isolating malicious actors through metric friction rather than voting ({ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`).
 
 **Repackaging (directly inherited ingredients, organized by domain):**
@@ -396,7 +396,7 @@ This framework introduces a unified nomenclature. While these terms may seem nov
 | **Ontology learning**               | implicit via representation                  | explicit fission criterion: when texture becomes predictable ($\Xi > \Xi_{\text{crit}}$), chart bifurcation expands categories; hysteresis thermodynamically calibrated ({ref}`Section 30 <sec-ontological-expansion-topological-fission-and-the-semantic-vacuum>`)                                                                                                                                                                                                                                                                                              |
 | **Gauge structure**                 | implicit or absent                           | explicit gauge group $G_{\text{Fragile}} = SU(N_f)_C \times SU(2)_L \times U(1)_Y$ with three derived gauge fields; covariant derivative ensures coordinate-invariant dynamics ({ref}`Section 34 <sec-standard-model-cognition>`)                                                                                                                                                                                                                                                                                                                                 |
 | **Hyperparameter tuning**           | grid search, Bayesian optimization           | Parameter Space Sieve derives operational constants from constraint satisfaction; feasible region defined by causal, holographic, metabolic, and stiffness bounds ({ref}`Section 35 <sec-parameter-space-sieve>`)                                                                                                                                                                                                                                                                                                                                                 |
-| **Economic agents**                 | separate game-theoretic models               | Partially Observable Markov Wealth (POMW) unifies economic dynamics with agent geometry; wealth as conserved quantity under metabolic constraints ({ref}`Part IX <sec-pomw>`)                                                                                                                                                                                                                                                                                                                                                                                     |
+| **Economic agents**                 | separate game-theoretic models               | Partially Observable Markov Wealth (POMW) unifies economic dynamics with agent geometry; wealth as conserved quantity under metabolic constraints ({ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`)                                                                                                                                                                                                                                                                                                                                                     |
 | **Blockchain consensus**            | Proof of Work (useless hash mining)          | Proof of Useful Work: gradients replace hashes; energy produces intelligence not heat; adversaries geometrically damped via metric friction; 51% attacks trigger Spontaneous Fission ({ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`)                                                                                                                                                                                                                                                                                                |
 
 **Reading guide (connections by section).**
@@ -420,9 +420,9 @@ This framework introduces a unified nomenclature. While these terms may seem nov
 - Causal information bound and representational limits: {ref}`Section 33 <sec-causal-information-bound>`
 - Gauge-theoretic unification (Standard Model of Cognition): {ref}`Section 34 <sec-standard-model-cognition>`
 - Fundamental constants from constraints (Parameter Space Sieve): {ref}`Section 35 <sec-parameter-space-sieve>`
-- Metabolic transducer and energy-information coupling: {ref}`Part VII <sec-metabolic-transducer>`
-- Intersubjective metric and shared meaning: {ref}`Part VII <sec-intersubjective-metric>`
-- Economic applications (Partially Observable Markov Wealth): {ref}`Part IX <sec-pomw>`
+- Metabolic transducer and energy-information coupling: {ref}`Part VII <sec-the-metabolic-transducer-autopoiesis-and-the-szilard-engine>`
+- Intersubjective metric and shared meaning: {ref}`Part VII <sec-the-inter-subjective-metric-gauge-locking-and-the-emergence-of-objective-reality>`
+- Economic applications (Partially Observable Markov Wealth): {ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`
 - Frequently asked questions (rigorous objections and responses): {ref}`Appendix D <sec-appendix-d-frequently-asked-questions>`
 
 (sec-for-skeptical-readers)=
@@ -504,15 +504,15 @@ The document is organized into nine parts plus appendices:
 - **{ref}`Section 31 <sec-computational-metabolism-the-landauer-bound-and-deliberation-dynamics>`**: Computational metabolism—Landauer bound, deliberation dynamics, fast/slow phase transition
 - **{ref}`Section 32 <sec-causal-discovery-interventional-geometry-and-the-singularity-of-action>`**: Causal discovery—interventional geometry, curiosity force, causal enclosure
 - **{ref}`Section 33 <sec-causal-information-bound>`**: The Causal Information Bound—area law for representational capacity; Causal Stasis
-- **{ref}`Section 33.5 <sec-metabolic-transducer>`**: Metabolic transducer—energy-information coupling, Landauer-bounded updates, fast/slow phase transitions
-- **{ref}`Section 33.6 <sec-intersubjective-metric>`**: Intersubjective metric—shared semantic space, language grounding, multi-agent meaning alignment
+- **{ref}`Section 33.5 <sec-the-metabolic-transducer-autopoiesis-and-the-szilard-engine>`**: Metabolic transducer—energy-information coupling, Landauer-bounded updates, fast/slow phase transitions
+- **{ref}`Section 33.6 <sec-the-inter-subjective-metric-gauge-locking-and-the-emergence-of-objective-reality>`**: Intersubjective metric—shared semantic space, language grounding, multi-agent meaning alignment
 
 **Part VIII: Multi-Agent Gauge Theory ({ref}`Sections 34–35 <sec-standard-model-cognition>`)**
 - **{ref}`Section 34 <sec-standard-model-cognition>`**: The Standard Model of Cognition—gauge-theoretic formulation; $G_{\text{Fragile}} = SU(N_f)_C \times SU(2)_L \times U(1)_Y$; belief spinors; ontological symmetry breaking
 - **{ref}`Section 35 <sec-parameter-space-sieve>`**: The Parameter Space Sieve—deriving fundamental constants from constraint satisfaction; causal, holographic, metabolic, coupling, stiffness, and screening bounds
 
 **Part IX: Economics**
-- **{ref}`Section 36 <sec-pomw>`**: Partially Observable Markov Wealth (POMW)—economic applications, resource allocation, game-theoretic wealth dynamics
+- **{ref}`Section 36 <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`**: Partially Observable Markov Wealth (POMW)—economic applications, resource allocation, game-theoretic wealth dynamics
 
 **Appendices**
 - **{ref}`Appendix A <sec-appendix-a-full-derivations>`**: Full derivations of the capacity-constrained curvature functional and the Area Law coefficient (A.6)
@@ -583,9 +583,9 @@ where:
 | 31 | Mean-Field Games (MFG)     | Mean-Field Metric Law + Geometric Locking                          | Finite $N$                                                              | {ref}`29.8 <sec-mean-field-metric-law>`                                                   |
 | 32 | Scalar reward shaping        | Gauge-covariant value transport                                    | Abelian limit ($SU(2), SU(N_f) \to 1$)                              | {ref}`34.1 <sec-gauge-principle-derivation>`                                              |
 | 33 | Hand-tuned hyperparameters   | Parameter Space Sieve (Constrained Optimization)                   | Remove constraints ($\mathcal{S} \to 0$)                            | {ref}`35 <sec-parameter-space-sieve>`                                                     |
-| 34 | System 1/2 heuristics          | Metabolic Transducer (Landauer-bounded switching)                  | Remove energy accounting                                            | {ref}`Part VII <sec-metabolic-transducer>`                                                |
-| 35 | Multi-agent language alignment | Intersubjective Metric (geometric semantic grounding)              | Independent representations                                         | {ref}`Part VII <sec-intersubjective-metric>`                                              |
-| 36 | Economic game theory           | POMW (wealth as conserved geometric quantity)                      | Decouple economics from geometry                                    | {ref}`Part IX <sec-pomw>`                                                                 |
+| 34 | System 1/2 heuristics          | Metabolic Transducer (Landauer-bounded switching)                  | Remove energy accounting                                            | {ref}`Part VII <sec-the-metabolic-transducer-autopoiesis-and-the-szilard-engine>`                                                |
+| 35 | Multi-agent language alignment | Intersubjective Metric (geometric semantic grounding)              | Independent representations                                         | {ref}`Part VII <sec-the-inter-subjective-metric-gauge-locking-and-the-emergence-of-objective-reality>`                                              |
+| 36 | Economic game theory           | POMW (wealth as conserved geometric quantity)                      | Decouple economics from geometry                                    | {ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`                                                                 |
 | 37 | Bitcoin/Proof of Work          | Proof of Useful Work (gradient mining + geometric consensus)       | Remove Sieve, use useless hashes, vote-based BFT                    | {ref}`Part IX <sec-proof-of-useful-work-cognitive-metabolism-as-consensus>`               |
 
 **The Five Degeneracy Classes:**

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2121,3 +2121,95 @@
   pages   = {1608--1613},
   year    = {1979}
 }
+
+@article{Tits72,
+  author  = {Jacques Tits},
+  title   = {Free Subgroups in Linear Groups},
+  journal = {Journal of Algebra},
+  volume  = {20},
+  number  = {2},
+  pages   = {250--270},
+  year    = {1972},
+  doi     = {10.1016/0021-8693(72)90058-0}
+}
+
+@incollection{Gromov87,
+  author    = {Mikhail Gromov},
+  title     = {Hyperbolic Groups},
+  booktitle = {Essays in Group Theory},
+  series    = {Mathematical Sciences Research Institute Publications},
+  volume    = {8},
+  pages     = {75--263},
+  publisher = {Springer},
+  address   = {New York},
+  year      = {1987},
+  doi       = {10.1007/978-1-4613-9586-7_3}
+}
+
+@book{BridsonHaefliger99,
+  author    = {Martin R. Bridson and André Haefliger},
+  title     = {Metric Spaces of Non-Positive Curvature},
+  series    = {Grundlehren der mathematischen Wissenschaften},
+  volume    = {319},
+  publisher = {Springer-Verlag},
+  address   = {Berlin},
+  year      = {1999},
+  doi       = {10.1007/978-3-662-12494-9},
+  isbn      = {978-3-540-64324-1}
+}
+
+@book{Lubotzky94,
+  author    = {Alexander Lubotzky},
+  title     = {Discrete Groups, Expanding Graphs and Invariant Measures},
+  series    = {Progress in Mathematics},
+  volume    = {125},
+  publisher = {Birkhäuser},
+  address   = {Basel},
+  year      = {1994},
+  doi       = {10.1007/978-3-0346-0332-4},
+  isbn      = {978-3-0346-0331-7}
+}
+
+@article{Selberg56,
+  author  = {Atle Selberg},
+  title   = {Harmonic Analysis and Discontinuous Groups in Weakly Symmetric {R}iemannian Spaces with Applications to {D}irichlet Series},
+  journal = {Journal of the Indian Mathematical Society},
+  volume  = {20},
+  pages   = {47--87},
+  year    = {1956}
+}
+
+@incollection{MontgomeryOdlyzko73,
+  author    = {Hugh L. Montgomery},
+  title     = {The Pair Correlation of Zeros of the Zeta Function},
+  booktitle = {Analytic Number Theory},
+  series    = {Proceedings of Symposia in Pure Mathematics},
+  volume    = {24},
+  pages     = {181--193},
+  publisher = {American Mathematical Society},
+  year      = {1973},
+  note      = {With contributions from F. Odlyzko on numerical verification}
+}
+
+@incollection{Sarnak95,
+  author    = {Peter Sarnak},
+  title     = {Arithmetic Quantum Chaos},
+  booktitle = {The Schur Lectures},
+  series    = {Israel Mathematical Conference Proceedings},
+  volume    = {8},
+  pages     = {183--236},
+  publisher = {Bar-Ilan University},
+  address   = {Ramat Gan},
+  year      = {1995}
+}
+
+@book{KatzSarnak99,
+  author    = {Nicholas M. Katz and Peter Sarnak},
+  title     = {Random Matrices, {F}robenius Eigenvalues, and Monodromy},
+  series    = {American Mathematical Society Colloquium Publications},
+  volume    = {45},
+  publisher = {American Mathematical Society},
+  address   = {Providence, RI},
+  year      = {1999},
+  isbn      = {978-0-8218-1017-0}
+}

--- a/docs/source/2_hypostructure/01_foundations/01_categorical.md
+++ b/docs/source/2_hypostructure/01_foundations/01_categorical.md
@@ -165,7 +165,7 @@ Let $\mathcal{S}$ be a structural flow datum with **strict dissipation** (i.e., 
 :::
 
 :::{prf:proof} Proof Sketch (for strict dissipation)
-:label: sketch-mt-krnl-consistency
+<!-- label: sketch-mt-krnl-consistency -->
 
 *Step 1 (1 ⇒ 2).* If $\mathcal{S}$ satisfies the axioms, then by the Dissipation axiom ($D_E$), energy is non-increasing: $\Phi(S_t x) \leq \Phi(x)$. Combined with the Compactness axiom, bounded orbits have convergent subsequences. Any limit point $x^*$ satisfies $S_t x^* = x^*$ by continuity.
 
@@ -229,13 +229,13 @@ then Interface Permit $\mathrm{Rep}_K(T, Z)$ holds, and hence the conjecture for
 :::
 
 :::{prf:proof}
-:label: proof-thm-categorical-completeness
+<!-- label: proof-thm-categorical-completeness -->
 
 See the Initiality Lemma (N9) and Cofinality argument below.
 :::
 
 :::{prf:proof} Initiality Lemma (Proof of N9)
-:label: proof-initiality-lemma
+<!-- label: proof-initiality-lemma -->
 
 The universal Rep-breaking pattern $\mathbb{H}_{\mathrm{bad}}^{(T)}$ exists and is initial in the category of singularity patterns.
 
@@ -286,7 +286,7 @@ $$(\forall [P,\pi] \in \mathcal{G}_T.\, \mathbb{H}_{[P,\pi]} \to \mathbb{H}) \Ri
 :::
 
 :::{prf:proof} Proof of KRNL-Exclusion (Categorical Proof Template)
-:label: proof-mt-krnl-exclusion
+<!-- label: proof-mt-krnl-exclusion -->
 
 *Step 1 (Ambient Setup).* Let $\mathcal{E}$ be the cohesive $(\infty,1)$-topos containing $\mathbf{Hypo}_T$ as a full subcategory. By {cite}`Lurie09` §6.1, $\mathcal{E}$ admits an **internal logic** given by its subobject classifier $\Omega$. Propositions in $\mathcal{E}$ correspond to morphisms $p: 1 \to \Omega$ where $1$ is the terminal object.
 
@@ -369,7 +369,7 @@ The trichotomy theorem puts this into the categorical framework. Every breakdown
 :::
 
 :::{prf:proof} Proof Sketch
-:label: sketch-mt-krnl-trichotomy
+<!-- label: sketch-mt-krnl-trichotomy -->
 
 *Step 1 (Energy Dichotomy).* By (D), $\Phi(u(t))$ is non-increasing. Either $\Phi(u(t)) \to 0$ (dispersion, Mode D.D), or $\Phi(u(t)) \to \Phi_* > 0$ (concentration). This is the **concentration-compactness dichotomy** of {cite}`Lions84` Lemma I.1: for bounded sequences in Sobolev spaces, either mass disperses to infinity or concentrates at finitely many points.
 
@@ -423,7 +423,7 @@ Then:
 :::
 
 :::{prf:proof} Proof Sketch
-:label: sketch-mt-krnl-equivariance
+<!-- label: sketch-mt-krnl-equivariance -->
 
 *Step 1 (Risk Invariance).* By hypothesis (1), if $S \sim \mathcal{S}$ then $g \cdot S \sim \mathcal{S}$. The risk functional $R(\Theta) = \mathbb{E}_{S \sim \mathcal{S}}[\mathcal{L}(\Theta, S)]$ satisfies $R(g \cdot \Theta) = R(\Theta)$ by change of variables.
 
@@ -445,7 +445,7 @@ This theorem formalizes the phase transition detected by {prf:ref}`mt-krnl-horiz
 :::
 
 :::{prf:proof}
-:label: proof-thm-halting-ait-sieve-thermo
+<!-- label: proof-thm-halting-ait-sieve-thermo -->
 
 We establish the sharp phase boundary in four steps.
 
@@ -545,7 +545,7 @@ See {prf:ref}`thm-halting-ait-sieve-thermo` for the phase transition witness the
 :::
 
 :::{prf:proof} Proof
-:label: proof-mt-krnl-horizon-limit
+<!-- label: proof-mt-krnl-horizon-limit -->
 
 **Step 1 (Information-Theoretic Lower Bound)**:
 To decide membership in $\mathcal{I}$, the sieve must store a representation of $\mathcal{I}$ requiring at least $K(\mathcal{I})$ bits (by definition of Kolmogorov complexity). Any shorter representation would contradict the minimality of $K(\mathcal{I})$.

--- a/docs/source/2_hypostructure/01_foundations/02_constructive.md
+++ b/docs/source/2_hypostructure/01_foundations/02_constructive.md
@@ -517,8 +517,6 @@ For abstract cohesive toposes, this theorem is conditional on items (1)–(3). F
 :::
 
 :::{prf:proof}
-:label: proof-thm-expansion-adjunction
-
 *Step 1 (Ambient Setup & Canonical Embedding via Flat Modality).*
 By the axioms of cohesion {cite}`Lurie09`; {cite}`Schreiber13`, $\mathcal{E}$ admits the adjoint quadruple. Given the analytic space $\underline{X}$ from the Thin Kernel, we invoke the flat modality embedding. Let $\text{Disc}: \mathbf{Set} \to \mathcal{E}$ be the discrete functor. Since $\underline{X}$ carries a metric topology (locally Hessian or Polish with synthetic differential structure), we define the base stack $X_0 \in \mathcal{E}$ as the unique object satisfying:
 

--- a/docs/source/2_hypostructure/03_sieve/01_structural.md
+++ b/docs/source/2_hypostructure/03_sieve/01_structural.md
@@ -181,8 +181,8 @@ The key insight: this is not just a flowchart. It is a *proof*. Every path throu
 
 :::
 
-:::{tip} Interactive Viewing Options
-:class: dropdown
+:::{dropdown} 💡 Interactive Viewing Options
+:open:
 
 This diagram is large. For better viewing:
 - **Zoom**: Use your browser's zoom (Ctrl/Cmd + scroll)

--- a/docs/source/2_hypostructure/03_sieve/02_kernel.md
+++ b/docs/source/2_hypostructure/03_sieve/02_kernel.md
@@ -349,7 +349,6 @@ The sieve diagram is a directed acyclic graph (DAG). All edges, including dotted
 :::
 
 :::{prf:proof}
-:label: proof-thm-dag
 
 By inspection of the diagram: all solid edges flow downward (increasing node number or to barriers/modes), and all dotted surgery edges target nodes strictly later in the flow than their source mode. The restoration subtree (7a--7d) only exits forward to TopoCheck or TameCheck.
 
@@ -373,7 +372,6 @@ Each epoch terminates in finite time, visiting finitely many nodes.
 :::
 
 :::{prf:proof}
-:label: proof-thm-epoch-termination
 
 Immediate from {prf:ref}`thm-dag`: the DAG structure ensures no cycles, hence any path through the sieve has bounded length.
 
@@ -389,7 +387,6 @@ A complete sieve run consists of finitely many epochs.
 :::
 
 :::{prf:proof}
-:label: proof-thm-finite-runs
 
 Each surgery has an associated progress measure ({prf:ref}`def-progress-measures`):
 
@@ -434,7 +431,6 @@ Every transition in a sieve run is certificate-justified. Formally, if the sieve
 :::
 
 :::{prf:proof}
-:label: proof-thm-soundness
 
 By construction: {prf:ref}`def-node-evaluation` requires each node evaluation to produce a certificate, and {prf:ref}`def-edge-validity` requires edge validity.
 
@@ -509,7 +505,6 @@ This is crucial for reproducibility. Two implementations of the sieve that start
 :::
 
 :::{prf:proof}
-:label: proof-thm-closure-termination
 
 *Step 1 (Ambient Setup: Certificate Lattice).* Define the **certificate lattice** $(\mathcal{L}, \sqsubseteq)$ where:
 - $\mathcal{L} := \mathcal{P}(\mathcal{K}(T))$ is the power set of all certificates of type $T$

--- a/docs/source/2_hypostructure/04_nodes/01_gate_nodes.md
+++ b/docs/source/2_hypostructure/04_nodes/01_gate_nodes.md
@@ -437,7 +437,6 @@ Exponential volume growth with finite-dimensional asymptotic cone does NOT viola
 :::
 
 :::{prf:proof}
-:label: proof-lsi-finite-cone
 
 For metric space $(X,d)$ with $|B_r| \sim e^{\alpha r}$ and $\dim(\text{Cone}_\omega(X)) = n < \infty$:
 

--- a/docs/source/2_hypostructure/04_nodes/02_barrier_nodes.md
+++ b/docs/source/2_hypostructure/04_nodes/02_barrier_nodes.md
@@ -1,3 +1,5 @@
+# Barrier Nodes
+
 (sec-barrier-node-specs)=
 ## Barrier Node Specifications (Orange Nodes)
 

--- a/docs/source/2_hypostructure/04_nodes/03_surgery_nodes.md
+++ b/docs/source/2_hypostructure/04_nodes/03_surgery_nodes.md
@@ -1,3 +1,5 @@
+# Surgery Nodes
+
 (sec-surgery-node-specs)=
 ## Surgery Node Specifications (Purple Nodes)
 

--- a/docs/source/2_hypostructure/05_interfaces/01_gate_evaluator.md
+++ b/docs/source/2_hypostructure/05_interfaces/01_gate_evaluator.md
@@ -2,6 +2,8 @@
 title: "Universal Gate Evaluator Interface"
 ---
 
+# Universal Gate Evaluator Interface
+
 (sec-gate-evaluator-interface)=
 ## The Universal Gate Evaluator Interface
 

--- a/docs/source/2_hypostructure/05_interfaces/02_permits.md
+++ b/docs/source/2_hypostructure/05_interfaces/02_permits.md
@@ -195,7 +195,7 @@ The uniqueness part is remarkable: any other functional with these properties is
 :::{prf:theorem} [KRNL-Lyapunov] Canonical Lyapunov Functional
 :label: mt-krnl-lyapunov
 
-**[Sieve Signature]**
+**[Sieve Signature: Canonical Lyapunov]**
 - **Requires:** $K_{D_E}^+$ AND $K_{C_\mu}^+$ AND $K_{\mathrm{LS}_\sigma}^+$
 - **Produces:** $K_{\mathcal{L}}^+$ (Lyapunov functional exists)
 - **Output:** Canonical loss $\mathcal{L}$ = optimal-transport cost to equilibrium
@@ -228,7 +228,6 @@ $$
 :::
 
 :::{prf:proof}
-:label: proof-mt-krnl-lyapunov
 
 *Step 1 (Well-definedness).* Define $\mathcal{L}$ via inf-convolution as above. The functional is well-defined since $\mathfrak{D} \geq 0$ implies $\mathcal{C} \geq 0$. By the **direct method of calculus of variations** ({cite}`Dacorogna08` Chapter 3): $C_\mu$ provides compactness of sublevel sets, and $\Phi + \mathcal{C}$ is lower semicontinuous (as sum of l.s.c. functions). Therefore the infimum is attained at some $y^* \in M$.
 
@@ -266,7 +265,7 @@ This connection to Riemannian geometry is powerful because it imports the entire
 :::{prf:theorem} [KRNL-Jacobi] Action Reconstruction
 :label: mt-krnl-jacobi
 
-**[Sieve Signature]**
+**[Sieve Signature: Jacobi Metric]**
 - **Requires:** $K_{D_E}^+$ AND $K_{\mathrm{LS}_\sigma}^+$ AND $K_{\mathrm{GC}_\nabla}^+$
 - **Produces:** $K_{\text{Jacobi}}^+$ (Jacobi metric reconstruction)
 - **Output:** $\mathcal{L}(x) = \mathrm{dist}_{g_{\mathfrak{D}}}(x, M)$
@@ -295,7 +294,6 @@ $$
 :::
 
 :::{prf:proof}
-:label: proof-mt-krnl-jacobi
 
 *Step 1 (Gradient Consistency).* Interface permit $\mathrm{GC}_\nabla$ asserts: along gradient flow $\dot{u} = -\nabla_g \Phi$, we have $\|\dot{u}(t)\|_g^2 = \mathfrak{D}(u(t))$. This identifies dissipation with squared velocity.
 
@@ -331,7 +329,7 @@ The Lyapunov functional satisfies a static Hamilton-Jacobi equation, providing a
 :::{prf:theorem} [KRNL-HamiltonJacobi] Hamilton-Jacobi Characterization
 :label: mt-krnl-hamilton-jacobi
 
-**[Sieve Signature]**
+**[Sieve Signature: Hamilton-Jacobi PDE]**
 - **Requires:** $K_{D_E}^+$ AND $K_{\mathrm{LS}_\sigma}^+$ AND $K_{\mathrm{GC}_\nabla}^+$
 - **Produces:** $K_{\text{HJ}}^+$ (Hamilton-Jacobi PDE characterization)
 - **Output:** $\|\nabla_g \mathcal{L}\|_g^2 = \mathfrak{D}$ with $\mathcal{L}|_M = \Phi_{\min}$
@@ -362,7 +360,6 @@ $$
 :::
 
 :::{prf:proof}
-:label: proof-mt-krnl-hamilton-jacobi
 
 *Step 1 (Eikonal for Distance).* In any Riemannian manifold, the distance function $d_M(x) = \mathrm{dist}(x, M)$ satisfies the eikonal equation $\|\nabla d_M\| = 1$ almost everywhere (away from cut locus). For $g_{\mathfrak{D}}$:
 
@@ -424,7 +421,7 @@ This extends $\mathrm{GC}_\nabla$ from Riemannian to general metric spaces.
 :::{prf:theorem} [KRNL-MetricAction] Extended Action Reconstruction
 :label: mt-krnl-metric-action
 
-**[Sieve Signature]**
+**[Sieve Signature: Metric Action]**
 - **Requires:** $K_{D_E}^+$ AND $K_{\mathrm{LS}_\sigma}^+$ AND $K_{\mathrm{GC}'_\nabla}^+$
 - **Produces:** $K_{\mathcal{L}}^{\text{metric}}$ (Lyapunov on metric spaces)
 - **Extends:** Riemannian → Wasserstein → Discrete
@@ -450,7 +447,6 @@ where $|\dot{\gamma}|$ denotes the metric derivative and the infimum ranges over
 :::
 
 :::{prf:proof}
-:label: proof-mt-krnl-metric-action
 
 *Step 1 (Metric Derivative Identity).* For absolutely continuous curves $\gamma: [0,1] \to \mathcal{X}$, the metric derivative is $|\dot{\gamma}|(s) := \lim_{h \to 0} d(\gamma(s+h), \gamma(s))/|h|$. By $\mathrm{GC}'_\nabla$, along gradient flow curves: $|\dot{u}|(t)^2 = \mathfrak{D}(u(t)) = |\partial\Phi|^2(u(t))$, hence $|\dot{u}|(t) = |\partial\Phi|(u(t))$.
 
@@ -536,7 +532,7 @@ $$
 ::::{prf:theorem} [RESOLVE-Tower] Soft Local Tower Globalization
 :label: mt-resolve-tower
 
-**Sieve Signature:**
+**Sieve Signature: Tower Globalization**
 - *Weakest Precondition:* $K_{C_\mu^{\mathrm{tower}}}^+$, $K_{D_E^{\mathrm{tower}}}^+$, $K_{\mathrm{SC}_\lambda^{\mathrm{tower}}}^+$, $K_{\mathrm{Rep}_K^{\mathrm{tower}}}^+$
 - *Produces:* $K_{\mathrm{Global}}^+$ (global asymptotic structure)
 - *Invalidated By:* Local-global obstruction
@@ -565,7 +561,6 @@ $$
 ::::
 
 :::{prf:proof}
-:label: proof-mt-resolve-tower
 
 *Step 1 (Existence of limit).* By $K_{C_\mu^{\mathrm{tower}}}^+$, the spaces $\{X_t\}$ at each level are precompact modulo symmetries. The transition maps $S_{t \to s}$ are compatible by the semiflow property. By $K_{D_E^{\mathrm{tower}}}^+$, the total dissipation is finite:
 
@@ -665,7 +660,7 @@ $$
 ::::{prf:theorem} [RESOLVE-Obstruction] Obstruction Capacity Collapse
 :label: mt-resolve-obstruction
 
-**Sieve Signature:**
+**Sieve Signature: Obstruction Collapse**
 - *Weakest Precondition:* $K_{\mathrm{TB}+\mathrm{LS}}^{\mathcal{O}+}$, $K_{C+\mathrm{Cap}}^{\mathcal{O}+}$, $K_{\mathrm{SC}_\lambda}^{\mathcal{O}+}$, $K_{D_E}^{\mathcal{O}+}$
 - *Produces:* $K_{\mathrm{Obs}}^{\mathrm{finite}}$ (obstruction sector is finite)
 - *Invalidated By:* Infinite obstruction accumulation
@@ -688,7 +683,6 @@ $$
 ::::
 
 :::{prf:proof}
-:label: proof-mt-resolve-obstruction
 
 *Step 1 (Finiteness at each scale).* Fix a scale $t$. By $K_{C+\mathrm{Cap}}^{\mathcal{O}+}$, the sublevel set $\mathcal{O}_t^{\leq B} := \{x \in \mathcal{O}_t : H_{\mathcal{O}}(x) \leq B\}$ is finite or compact for each $B > 0$.
 
@@ -738,7 +732,7 @@ Guarantees no hidden "ghost sectors" where singularities can hide. All degrees o
 ::::{prf:theorem} [KRNL-StiffPairing] Stiff Pairing / No Null Directions
 :label: mt-krnl-stiff-pairing
 
-**Sieve Signature:**
+**Sieve Signature: Stiff Pairing**
 - *Weakest Precondition:* $K_{\mathrm{LS}_\sigma}^+$, $K_{\mathrm{TB}_\pi}^+$, $K_{\mathrm{GC}_\nabla}^+$
 - *Produces:* $K_{\mathrm{Stiff}}^+$ (no null directions)
 - *Invalidated By:* Hidden degeneracy
@@ -770,7 +764,6 @@ Let $\mathcal{X} = X_{\mathrm{free}} \oplus X_{\mathrm{obs}} \oplus X_{\mathrm{r
 ::::
 
 :::{prf:proof}
-:label: proof-mt-krnl-stiff-pairing
 
 *Step 1 (Pairing structure).* The pairing induces $\Psi: \mathcal{X} \to \mathcal{X}^*$, $\Psi(x)(y) := \langle x, y \rangle$. By $K_{\mathrm{LS}_\sigma}^+ + K_{\mathrm{TB}_\pi}^+$, this map is injective on $X_{\mathrm{free}} \oplus X_{\mathrm{obs}}$.
 

--- a/docs/source/2_hypostructure/05_interfaces/03_contracts.md
+++ b/docs/source/2_hypostructure/05_interfaces/03_contracts.md
@@ -189,5 +189,3 @@ There are two strategies, and you must pick one.
 The Zeno remark is worth understanding deeply. Zeno's paradox asks: how can Achilles catch the tortoise if he must first reach where the tortoise was, then where it moved to, and so on forever? The resolution is that infinitely many steps can happen in finite time if the steps get small enough fast enough. But for surgeries, we do not want that! Each surgery is a discrete computational step, and we cannot perform infinitely many of them. The $\epsilon_T$ constraint is our anti-Zeno shield.
 
 :::
-
----

--- a/docs/source/2_hypostructure/05_interfaces/03_contracts.md
+++ b/docs/source/2_hypostructure/05_interfaces/03_contracts.md
@@ -58,7 +58,6 @@ A barrier invoked because $P_i$ failed cannot assume $P_i$ as a prerequisite.
 :::
 
 :::{prf:proof}
-:label: prf-barrier-noncircular
 
 Suppose toward contradiction that $P_i \in \mathrm{Pre}(B)$.
 

--- a/docs/source/2_hypostructure/06_modules/01_singularity.md
+++ b/docs/source/2_hypostructure/06_modules/01_singularity.md
@@ -129,8 +129,8 @@ Routes to T.C/D.C-family modes for reconstruction or explicit wildness acknowled
 
 :::
 
-:::{prf:proof} Proof Sketch
-:label: sketch-mt-resolve-profile
+:::{prf:proof}
+Proof Sketch
 
 *Step 1 (Limit Extraction).* Given singularity sequence $(t_n, x_n) \to (T_*, x_*)$ with $t_n \nearrow T_*$, apply compactness modulo symmetry (from $C_\mu$): there exist $g_n \in G$ such that $g_n \cdot u(t_n)$ has a convergent subsequence $\to V$.
 
@@ -297,7 +297,6 @@ The Automation Guarantee ensures at least one of these conditions holds for "goo
 :::
 
 :::{prf:proof}
-:label: proof-mt-resolve-auto-profile
 
 ### Dispatcher Logic
 
@@ -548,8 +547,8 @@ Explicit reason certificate:
 
 :::
 
-:::{prf:proof} Proof Sketch
-:label: sketch-mt-resolve-admissibility
+:::{prf:proof}
+Proof Sketch
 
 *Step 1 (Canonicity Verification).* Given surgery data $(\Sigma, V)$, query profile library: is $V \in \mathcal{L}_T$? If yes, proceed. If $V \in \mathcal{F}_T \setminus \mathcal{L}_T$, check for equivalence move (YES$^\sim$). If $V \notin \mathcal{F}_T$, return Case 3 (Horizon).
 
@@ -645,8 +644,8 @@ using the measure $\mu$ from $\mathcal{X}^{\text{thin}}$ and the metric $d$.
 **Literature:** Sobolev capacity {cite}`AdamsHedberg96`; Hausdorff dimension bounds {cite}`Federer69`.
 :::
 
-:::{prf:proof} Proof Sketch
-:label: sketch-mt-resolve-auto-admit
+:::{prf:proof}
+Proof Sketch
 
 *Step 1 (Thin Object Extraction).* From $\mathcal{X}^{\text{thin}} = (\mathcal{X}, d, \mu)$, extract the metric structure for capacity computation. From $\mathfrak{D}^{\text{thin}} = (R, \beta)$, identify the singular locus $\Sigma = \{x : R(x) \to \infty\}$.
 
@@ -707,8 +706,8 @@ Let $M$ be a failure mode with breach certificate $K^{\mathrm{br}}$, and let $S$
 
 :::
 
-:::{prf:proof} Proof Sketch
-:label: sketch-mt-act-surgery
+:::{prf:proof}
+Proof Sketch
 
 *Step 1 (Excision).* Given admissible singularity $(\Sigma, V)$ with $\text{Cap}(\Sigma) \leq \varepsilon_{\text{adm}}$, remove neighborhood $\mathcal{X}_\Sigma = B_\epsilon(\Sigma)$. The removed region has controlled measure: $\mu(\mathcal{X}_\Sigma) \lesssim \epsilon^2 \cdot \text{Cap}(\Sigma)$.
 
@@ -798,8 +797,8 @@ For any admissible surgery $\mathcal{O}_S: \mathcal{X} \dashrightarrow \mathcal{
    Since each surgery drops energy by at least $\epsilon_T > 0$, the surgery count is explicitly bounded. This is a finite natural number, not merely an abstract well-foundedness argument.
 :::
 
-:::{prf:proof} Proof Sketch
-:label: sketch-mt-resolve-conservation
+:::{prf:proof}
+Proof Sketch
 
 *Step 1 (Energy Drop).* The excised region $\mathcal{X}_\Sigma$ contains concentrated curvature/energy. By the isoperimetric inequality and capacity bounds:
 
@@ -861,8 +860,8 @@ For any Hypostructure satisfying the Automation Guarantee, the Structural Surger
 **Literature:** Pushouts in category theory {cite}`MacLane71`; surgery caps in geometric flows {cite}`Hamilton97`; {cite}`KleinerLott08`.
 :::
 
-:::{prf:proof} Proof Sketch
-:label: sketch-mt-resolve-auto-surgery
+:::{prf:proof}
+Proof Sketch
 
 *Step 1 (Cap Existence).* Given profile $V \in \mathcal{L}_T$ with finite automorphism group, asymptotic analysis determines a unique cap geometry matching $V$'s asymptotic expansion. For Ricci flow, this is the Bryant soliton; for MCF, this is the standard cylinder cap.
 

--- a/docs/source/2_hypostructure/06_modules/03_lock.md
+++ b/docs/source/2_hypostructure/06_modules/03_lock.md
@@ -60,7 +60,7 @@ The Lock attempts thirteen proof-producing tactics to establish Hom-emptiness:
 :::{prf:definition} E1: Dimension obstruction
 :label: def-e1
 
-**Sieve Signature:**
+**Sieve Signature (E1):**
 - **Required Permits:** $\mathrm{Rep}_K$ (representability), $\mathrm{Cat}_{\mathrm{Hom}}$
 - **Weakest Precondition:** $\{K_{\mathrm{Rep}_K}^+\}$ (finite representability confirmed)
 - **Produces:** $K_{\mathrm{E1}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$ (Hom-emptiness via dimension)
@@ -92,7 +92,7 @@ E1 is the simplest obstruction: dimension counting. You cannot fit a three-dimen
 :::{prf:definition} E2: Invariant mismatch
 :label: def-e2
 
-**Sieve Signature:**
+**Sieve Signature (E2):**
 - **Required Permits:** $\mathrm{Rep}_K$, $\mathrm{TB}_\pi$ (topological background), $\mathrm{Cat}_{\mathrm{Hom}}$
 - **Weakest Precondition:** $\{K_{\mathrm{Rep}_K}^+, K_{\mathrm{TB}_\pi}^+\}$
 - **Produces:** $K_{\mathrm{E2}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
@@ -124,7 +124,7 @@ E2 uses topological invariants. Even if two spaces have the same dimension, they
 :::{prf:definition} E3: Positivity obstruction
 :label: def-e3
 
-**Sieve Signature:**
+**Sieve Signature (E3):**
 - **Required Permits:** $D_E$ (energy), $\mathrm{LS}_\sigma$ (local stiffness), $\mathrm{Cat}_{\mathrm{Hom}}$
 - **Weakest Precondition:** $\{K_{D_E}^+, K_{\mathrm{LS}_\sigma}^+\}$
 - **Produces:** $K_{\mathrm{E3}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
@@ -156,7 +156,7 @@ E3 is about positivity constraints. Physical systems often require energy to be 
 :::{prf:definition} E4: Integrality obstruction
 :label: def-e4
 
-**Sieve Signature:**
+**Sieve Signature (E4):**
 - **Required Permits:** $\mathrm{Rep}_K$, $\mathrm{Cat}_{\mathrm{Hom}}$
 - **Weakest Precondition:** $\{K_{\mathrm{Rep}_K}^+\}$ (arithmetic structure available)
 - **Produces:** $K_{\mathrm{E4}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
@@ -184,7 +184,7 @@ $$
 :::{prf:definition} E5: Functional equation obstruction
 :label: def-e5
 
-**Sieve Signature:**
+**Sieve Signature (E5):**
 - **Required Permits:** $\mathrm{Rep}_K$, $\mathrm{GC}_\nabla$ (gauge covariance), $\mathrm{Cat}_{\mathrm{Hom}}$
 - **Weakest Precondition:** $\{K_{\mathrm{Rep}_K}^+\}$
 - **Produces:** $K_{\mathrm{E5}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
@@ -216,7 +216,7 @@ E4 and E5 deal with discrete arithmetic and functional constraints. Sometimes th
 :::{prf:definition} E6: Causal obstruction (Well-Foundedness)
 :label: def-e6
 
-**Sieve Signature:**
+**Sieve Signature (E6):**
 - **Required Permits:** $\mathrm{TB}_\pi$ (topological/causal structure), $D_E$ (dissipation), $\mathrm{Cat}_{\mathrm{Hom}}$
 - **Weakest Precondition:** $\{K_{\mathrm{TB}_\pi}^+, K_{D_E}^+\}$ (causal structure and energy bound available)
 - **Produces:** $K_{\mathrm{E6}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
@@ -248,7 +248,7 @@ E6 is deep. It says: if the bad pattern contains closed timelike curves, infinit
 :::{prf:definition} E7: Thermodynamic obstruction (Entropy)
 :label: def-e7
 
-**Sieve Signature:**
+**Sieve Signature (E7):**
 - **Required Permits:** $D_E$ (dissipation/energy), $\mathrm{SC}_\lambda$ (scaling/entropy), $\mathrm{Cat}_{\mathrm{Hom}}$
 - **Weakest Precondition:** $\{K_{D_E}^+, K_{\mathrm{SC}_\lambda}^+\}$ (energy dissipation and scaling available)
 - **Produces:** $K_{\mathrm{E7}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
@@ -280,7 +280,7 @@ E7 is the Second Law as a morphism obstruction. If the bad pattern requires entr
 :::{prf:definition} E8: Data Processing Interaction (DPI)
 :label: def-e8
 
-**Sieve Signature:**
+**Sieve Signature (E8):**
 - **Required Permits:** $\mathrm{Cap}_H$ (capacity), $\mathrm{TB}_\pi$ (topological boundary), $\mathrm{Cat}_{\mathrm{Hom}}$
 - **Weakest Precondition:** $\{K_{\mathrm{Cap}_H}^+, K_{\mathrm{TB}_\pi}^+\}$ (capacity bound and topology available)
 - **Produces:** $K_{\mathrm{E8}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
@@ -312,7 +312,7 @@ E8 uses information theory. The boundary of your system acts like a communicatio
 :::{prf:definition} E9: Ergodic obstruction (Mixing)
 :label: def-e9
 
-**Sieve Signature:**
+**Sieve Signature (E9):**
 - **Required Permits:** $\mathrm{TB}_\rho$ (mixing/ergodic structure), $C_\mu$ (compactness), $\mathrm{Cat}_{\mathrm{Hom}}$
 - **Weakest Precondition:** $\{K_{\mathrm{TB}_\rho}^+, K_{C_\mu}^+\}$ (mixing rate and concentration available)
 - **Produces:** $K_{\mathrm{E9}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
@@ -344,7 +344,7 @@ E9 is about dynamics. A rapidly mixing system forgets its initial conditions exp
 :::{prf:definition} E10: Definability obstruction (Tameness)
 :label: def-e10
 
-**Sieve Signature:**
+**Sieve Signature (E10):**
 - **Required Permits:** $\mathrm{TB}_O$ (o-minimal/tame structure), $\mathrm{Rep}_K$ (representability), $\mathrm{Cat}_{\mathrm{Hom}}$
 - **Weakest Precondition:** $\{K_{\mathrm{TB}_O}^+, K_{\mathrm{Rep}_K}^+\}$ (tameness and finite representation available)
 - **Produces:** $K_{\mathrm{E10}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
@@ -373,16 +373,6 @@ $$
 E10 asks: is the bad pattern "tame" or "wild"? Tame topology, in the sense of o-minimal structures, has finite complexity. Wild topology, like an Alexander horned sphere, has infinite complexity. Tame structures cannot contain wild ones. This is not just a technicality; it is a fundamental barrier from model theory.
 :::
 
-:::{prf:definition} E11: Galois-Monodromy Lock
-:label: def-e11
-
-**Sieve Signature:**
-- **Required Permits:** $\mathrm{Rep}_K$ (representation/algebraic structure), $\mathrm{TB}_\pi$ (topology/monodromy), $\mathrm{Cat}_{\mathrm{Hom}}$
-- **Weakest Precondition:** $\{K_{\mathrm{Rep}_K}^+, K_{\mathrm{TB}_\pi}^+\}$ (Galois group and monodromy available)
-- **Produces:** $K_{\mathrm{E11}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
-- **Blocks:** S.E (Supercritical Cascade); S.C (Computational Overflow)
-- **Breached By:** Galois group solvable or monodromy finite
-
 :::{prf:definition} Galois Group
 :label: def-galois-group-permit
 
@@ -394,6 +384,16 @@ For a polynomial $f(x) \in \mathbb{Q}[x]$, the **Galois group** $\mathrm{Gal}(f)
 
 For a differential equation with singularities, the **monodromy group** $\mathrm{Mon}(f)$ describes how solutions transform when analytically continued around singularities.
 :::
+
+:::{prf:definition} E11: Galois-Monodromy Lock
+:label: def-e11
+
+**Sieve Signature (E11):**
+- **Required Permits:** $\mathrm{Rep}_K$ (representation/algebraic structure), $\mathrm{TB}_\pi$ (topology/monodromy), $\mathrm{Cat}_{\mathrm{Hom}}$
+- **Weakest Precondition:** $\{K_{\mathrm{Rep}_K}^+, K_{\mathrm{TB}_\pi}^+\}$ (Galois group and monodromy available)
+- **Produces:** $K_{\mathrm{E11}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
+- **Blocks:** S.E (Supercritical Cascade); S.C (Computational Overflow)
+- **Breached By:** Galois group solvable or monodromy finite
 
 **Method**: Galois theory / Monodromy representation analysis
 
@@ -426,7 +426,6 @@ $$
 :::
 
 :::{prf:proof} Proof Sketch (Abel-Ruffini)
-:label: proof-e11-abel-ruffini
 
 *Step 1 (Galois correspondence).* For $f(x) \in \mathbb{Q}[x]$ with splitting field $K$, the Galois group $\mathrm{Gal}(K/\mathbb{Q})$ embeds into $S_n$ via root permutations. The Fundamental Theorem establishes bijection: subgroups $H \subseteq \mathrm{Gal}(K/\mathbb{Q}) \leftrightarrow$ intermediate fields $\mathbb{Q} \subseteq F \subseteq K$.
 
@@ -445,23 +444,6 @@ E11 reaches deep into algebra. Remember Abel's proof that the general quintic ha
 
 The monodromy obstruction is the same idea for differential equations. When you analytically continue solutions around singularities, they transform. If the transformations form an infinite group, the solutions have infinitely many branches. This infinite complexity cannot embed into finite structures.
 :::
-
-:::{prf:definition} E12: Algebraic Compressibility (Permit Schema with Alternative Backends)
-:label: def-e12
-
-**Sieve Signature:**
-- **Required Permits (Alternative Backends):**
-  - **Backend A:** $K_{\mathrm{Rep}_K}^+$ (hypersurface) + $K_{\mathrm{SC}_\lambda}^{\text{deg}}$ → $K_{\mathrm{E12}}^{\text{hypersurf}}$
-  - **Backend B:** $K_{\mathrm{Rep}_K}^+$ (complete intersection) + $K_{\mathrm{SC}_\lambda}^{\text{Bez}}$ → $K_{\mathrm{E12}}^{\text{c.i.}}$
-  - **Backend C:** $K_{\mathrm{Rep}_K}^+$ (morphism) + $K_{\mathrm{DegImage}_m}^+$ + $K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\text{deg}}$ → $K_{\mathrm{E12}}^{\text{morph}}$
-- **Weakest Precondition:** $\{K_{\mathrm{Rep}_K}^+\}$ (algebraic variety structure available)
-- **Produces:** $K_{\mathrm{E12}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
-- **Blocks:** S.E (Supercritical Cascade); S.C (Computational Overflow)
-- **Breached By:** Degree compatibility, linear structure, or compatible morphism exists
-
-**Context:** Algebraic compressibility obstructions arise when attempting to approximate or represent a high-degree variety using lower-degree data. The degree of an algebraic variety is an intrinsic geometric invariant that resists compression.
-
-**Critical Remark:** The naive claim "degree $\delta$ cannot be represented by polynomials of degree $< \delta$" is **imprecise** for general varieties (e.g., a parametric representation can use lower-degree maps). The following backends make the obstruction precise by specifying what "representation" means.
 
 :::{prf:definition} Algebraic Variety
 :label: def-algebraic-variety-permit
@@ -486,6 +468,23 @@ $$
 counted with multiplicity. Equivalently, $\deg(V) = \int_V c_1(\mathcal{O}(1))^d$.
 :::
 
+:::{prf:definition} E12: Algebraic Compressibility (Permit Schema with Alternative Backends)
+:label: def-e12
+
+**Sieve Signature (E12):**
+- **Required Permits (Alternative Backends):**
+  - **Backend A:** $K_{\mathrm{Rep}_K}^+$ (hypersurface) + $K_{\mathrm{SC}_\lambda}^{\text{deg}}$ → $K_{\mathrm{E12}}^{\text{hypersurf}}$
+  - **Backend B:** $K_{\mathrm{Rep}_K}^+$ (complete intersection) + $K_{\mathrm{SC}_\lambda}^{\text{Bez}}$ → $K_{\mathrm{E12}}^{\text{c.i.}}$
+  - **Backend C:** $K_{\mathrm{Rep}_K}^+$ (morphism) + $K_{\mathrm{DegImage}_m}^+$ + $K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\text{deg}}$ → $K_{\mathrm{E12}}^{\text{morph}}$
+- **Weakest Precondition:** $\{K_{\mathrm{Rep}_K}^+\}$ (algebraic variety structure available)
+- **Produces:** $K_{\mathrm{E12}}^+ \Rightarrow K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{blk}}$
+- **Blocks:** S.E (Supercritical Cascade); S.C (Computational Overflow)
+- **Breached By:** Degree compatibility, linear structure, or compatible morphism exists
+
+**Context:** Algebraic compressibility obstructions arise when attempting to approximate or represent a high-degree variety using lower-degree data. The degree of an algebraic variety is an intrinsic geometric invariant that resists compression.
+
+**Critical Remark:** The naive claim "degree $\delta$ cannot be represented by polynomials of degree $< \delta$" is **imprecise** for general varieties (e.g., a parametric representation can use lower-degree maps). The following backends make the obstruction precise by specifying what "representation" means.
+
 **Certificate Logic:**
 
 $$
@@ -494,7 +493,7 @@ $$
 
 ---
 
-#### Backend A: Hypersurface Form
+### Backend A: Hypersurface Form
 
 **Hypotheses:**
 1. $V = Z(f) \subset \mathbb{P}^n$ is an **irreducible hypersurface**
@@ -507,7 +506,7 @@ $$
 
 ---
 
-#### Backend B: Complete Intersection Form
+### Backend B: Complete Intersection Form
 
 **Hypotheses:**
 1. $V \subset \mathbb{P}^n$ is a **complete intersection** of codimension $k$
@@ -520,7 +519,7 @@ $$
 
 ---
 
-#### Backend C: Morphism / Compression Form
+### Backend C: Morphism / Compression Form
 
 **Hypotheses:**
 1. $V \subset \mathbb{P}^n$ is an irreducible variety of dimension $d$ and degree $\delta$
@@ -550,7 +549,6 @@ $$
 :::
 
 :::{prf:proof} E12 Backend A (Hypersurface Form)
-:label: proof-e12-backend-a
 
 *Step 1 (Hypersurface Setup).* Let $V = Z(f)$ where $f$ is an irreducible homogeneous polynomial of degree $\delta$. The degree of $V$ as a variety equals $\delta$ (a generic line intersects $V$ in $\delta$ points by Bézout).
 
@@ -569,7 +567,6 @@ $$
 :::
 
 :::{prf:proof} E12 Backend B (Complete Intersection Form)
-:label: proof-e12-backend-b
 
 *Step 1 (Complete Intersection Definition).* $V$ is a complete intersection if it is cut out by exactly $\text{codim}(V)$ equations and has the expected dimension. The ideal $I_V = (f_1, \ldots, f_k)$ is generated by a regular sequence.
 
@@ -602,7 +599,6 @@ by AM-GM. If $d_1 \geq d_2 \geq \cdots \geq d_k$, then $d_1 \geq \deg(V)^{1/k}$.
 :::
 
 :::{prf:proof} E12 Backend C (Morphism / Compression Form)
-:label: proof-e12-backend-c
 
 *Step 1 (Morphism Degree Definition).* For a generically finite morphism $\phi: W \to V$, the **degree** $d_\phi$ is the generic fiber cardinality: $d_\phi = |\phi^{-1}(p)|$ for generic $p \in V$.
 

--- a/docs/source/2_hypostructure/07_factories/01_metatheorems.md
+++ b/docs/source/2_hypostructure/07_factories/01_metatheorems.md
@@ -51,7 +51,6 @@ For undecidable predicates (e.g., Gate 17), the framework uses the tactic librar
 :::
 
 :::{prf:proof}
-:label: proof-mt-fact-gate
 
 *Proof (Following Categorical Proof Template — Natural Transformation Soundness).*
 
@@ -215,7 +214,6 @@ For any system of type $T$, there exist default barrier implementations with cor
 :::
 
 :::{prf:proof}
-:label: proof-mt-fact-barrier
 
 *Step 1 (Barrier Catalog).* For each gate NO outcome, identify the corresponding barrier type from literature:
 - EnergyCheck NO $\to$ Foster-Lyapunov barrier (drift $\mathcal{L}V \leq -\gamma V + C\mathbf{1}_K$)
@@ -286,7 +284,6 @@ For any type $T$ admitting surgery, there exist default surgery operators matchi
 :::
 
 :::{prf:proof}
-:label: proof-mt-fact-surgery
 
 *Step 1 (Profile-Surgery Correspondence).* For each canonical profile $\mathcal{P}_i \in \mathcal{L}_T$, identify the corresponding surgery operator from literature:
 - Concentration profile $\to$ bubble extraction (blow-up analysis + rescaling)
@@ -369,7 +366,6 @@ For any type $T$, there exists a library of admissible equivalence moves and tra
 :::
 
 :::{prf:proof}
-:label: proof-mt-fact-transport
 
 *Step 1 (Equivalence Instantiation).* For each abstract equivalence $\mathrm{Eq}_i$, instantiate using the type's structural assumptions:
 - {prf:ref}`def-equiv-symmetry` (Scaling): $u \sim_\lambda \lambda^{\alpha} u(\lambda^\beta \cdot)$ with exponents from $T$'s critical scaling
@@ -448,7 +444,6 @@ For any type $T$ with $\mathrm{Rep}_K$ available, there exist E1--E10 tactics fo
 :::
 
 :::{prf:proof}
-:label: proof-mt-fact-lock
 
 *Step 1 (Tactic Classification).* The Lock backend tactics E1--E5 are instantiated from the type's representation substrate $\mathrm{Rep}_K$:
 - E1 (Geometric): Direct geometric obstruction (Hausdorff dimension, capacity bounds)

--- a/docs/source/2_hypostructure/07_factories/02_instantiation.md
+++ b/docs/source/2_hypostructure/07_factories/02_instantiation.md
@@ -93,7 +93,6 @@ For any system of type $T$ with user-supplied functionals, there exists a canoni
 :::
 
 :::{prf:proof}
-:label: proof-mt-fact-instantiation
 
 *Step 1 (Factory Composition).* Given type $T$ and user-supplied functionals $(\Phi, \mathfrak{D}, G, \ldots)$, apply factories TM-1 through TM-5 in sequence:
 - TM-1 instantiates gate evaluators $\{V_i^T\}_{i=1}^{17}$ from $(\Phi, \mathfrak{D})$

--- a/docs/source/2_hypostructure/08_upgrades/01_instantaneous.md
+++ b/docs/source/2_hypostructure/08_upgrades/01_instantaneous.md
@@ -72,8 +72,7 @@ $$K_{D_E}^- \wedge K_{\text{sat}}^{\mathrm{blk}} \Rightarrow K_{D_E}^{\sim}$$
 **Literature:** {cite}`MeynTweedie93`; {cite}`HairerMattingly11`
 :::
 
-:::{prf:proof} Proof Sketch
-:label: sketch-mt-up-saturation
+:::{prf:proof}
 
 The drift condition implies geometric ergodicity by the Foster-Lyapunov criterion (Meyn and Tweedie, 1993, Theorem 15.0.1). The invariant measure $\pi$ satisfies $\pi(\Phi) < \infty$ by Theorem 14.0.1 of the same reference. The renormalized height $\hat{\Phi} = \Phi - \pi(\Phi)$ is centered and the dynamics converge exponentially to equilibrium.
 :::
@@ -104,8 +103,7 @@ $$K_{\mathrm{Rec}_N}^- \wedge K_{\mathrm{Rec}_N}^{\mathrm{blk}} \Rightarrow K_{\
 **Literature:** {cite}`Penrose69`; {cite}`ChristodoulouKlainerman93`; {cite}`HawkingPenrose70`
 :::
 
-:::{prf:proof} Proof Sketch
-:label: sketch-mt-up-censorship
+:::{prf:proof}
 
 By the weak cosmic censorship conjecture (Penrose, 1969), generic gravitational collapse produces singularities cloaked by event horizons. The Hawking-Penrose theorems (1970) establish geodesic incompleteness, but the Christodoulou-Klainerman stability theorem (1993) ensures the exterior remains regular. Any observer worldline $\gamma \subset J^-(\mathcal{I}^+)$ experiences finite proper time and finite events before the singularity becomes causally relevant.
 :::
@@ -156,7 +154,6 @@ $$K_{C_\mu}^- \wedge K_{C_\mu}^{\mathrm{ben}} \Rightarrow \text{Global Regularit
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-scattering
 
 *Step 1 (Morawetz Spacetime Bound).* The **Morawetz estimate** ({cite}`Morawetz68`) provides spacetime integrability:
 
@@ -204,7 +201,6 @@ $$K_{\mathrm{SC}_\lambda}^- \wedge K_{\mathrm{SC}_\lambda}^{\mathrm{blk}} \Right
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-type-ii
 
 The monotonicity formula (Merle and Zaag, 1998) bounds the blow-up rate from below. For Type II blow-up, the energy remains bounded while the scale $\lambda(t) \to 0$. The logarithmic divergence of the renormalization integral creates an energy barrier that prevents finite-time singularity formation. This mechanism underlies the Raphaël-Szeftel soliton resolution (2011).
 :::
@@ -236,7 +232,6 @@ $$K_{\mathrm{Cap}_H}^- \wedge K_{\mathrm{Cap}_H}^{\mathrm{blk}} \Rightarrow K_{\
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-capacity
 
 By Federer's theorem on removable singularities (1969, Section 4.7), sets of zero $(1,p)$-capacity are removable for $W^{1,p}$ functions. For $p=2$, the extension follows from the Lax-Milgram theorem applied to the weak formulation. The uniqueness follows from the maximum principle. See also Evans and Gariepy (2015, Theorem 4.7.2).
 :::
@@ -268,7 +263,6 @@ $$K_{\mathrm{LS}_\sigma}^- \wedge K_{\text{gap}}^{\mathrm{blk}} \Rightarrow K_{\
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-spectral
 
 The Łojasiewicz-Simon inequality states $|\Phi(x) - \Phi(x^*)|^{1-\theta} \leq C\|\nabla\Phi(x)\|$ for some $\theta \in (0,1/2]$. When the Hessian is non-degenerate ($\lambda_1 > 0$), Taylor expansion gives $\theta = 1/2$. The exponential convergence then follows from the Gronwall inequality applied to the energy functional. See Simon (1983, Theorem 3) and Feehan and Maridakis (2019).
 :::
@@ -312,7 +306,6 @@ $$K_{\mathrm{TB}_O}^- \wedge K_{\mathrm{TB}_O}^{\mathrm{blk}} \Rightarrow K_{\ma
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-o-minimal
 
 *Step 1 (Cell Decomposition).* By the **cell decomposition theorem** ({cite}`vandenDries98` Theorem 3.2.11), every definable set $W \subset \mathbb{R}^n$ in an o-minimal structure admits a finite partition:
 
@@ -379,7 +372,6 @@ This **classification of local models** eliminates surgery ambiguity: the excisi
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-surgery
 
 The surgery construction follows Hamilton (1997) for Ricci flow and Perelman (2002-2003) for the rigorous completion. The key ingredients are: (1) canonical neighborhood theorem ensuring surgery regions are standard, (2) non-collapsing estimates controlling geometry, (3) finite surgery time theorem bounding the number of surgeries. The post-surgery manifold inherits all regularity properties.
 :::
@@ -423,7 +415,6 @@ $$K_{\text{Lock}}^{\mathrm{blk}} \Rightarrow \text{Global Regularity}$$
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-lock
 
 The proof uses the contrapositive: if a singularity existed, it would generate a non-trivial morphism $\phi: \mathcal{B}_{\text{univ}} \to \mathcal{H}$ by the universal property. The emptiness of the Hom-set is established via cohomological/spectral obstructions (E1-E10 tactics). This is the "Grothendieck yoga" of reducing existence questions to non-existence of maps. See SGA 4 for the categorical framework.
 :::
@@ -456,7 +447,6 @@ $$K_{D_E}^- \wedge K_{\mathrm{Bound}_\partial}^+ \wedge (\text{Flux} < 0) \Right
 ::::
 
 :::{prf:proof}
-:label: sketch-mt-up-absorbing
 
 The energy identity is $\frac{dE}{dt} = -\mathfrak{D}(t) + \int_{\partial\Omega} \mathbf{n} \cdot \mathbf{F} \, dS + \int_\Omega \text{source}(x,t) \, dx$. By hypothesis 3, the flux term satisfies $\int_{\partial\Omega} \mathbf{n} \cdot \mathbf{F} \, dS < 0$ (strictly outgoing). Since dissipation satisfies $\mathfrak{D}(t) \geq 0$, we have:
 
@@ -496,7 +486,6 @@ $$K_{\mathrm{LS}_\sigma}^- \wedge K_{\mathrm{LS}_{\partial^k V}}^+ \Rightarrow K
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-catastrophe
 
 The Łojasiewicz exponent at a degenerate critical point is $\theta = 1/k$ for the $A_{k-1}$ catastrophe (Thom, 1975). For the normal form $V(x) = x^{k+1}/(k+1)$ with critical point at $x^* = 0$, we have $\nabla V(x) = x^k$ and $V(x) - V(x^*) = x^{k+1}/(k+1)$. The Łojasiewicz gradient inequality $\|\nabla V(x)\| \geq C|V(x) - V(x^*)|^{1-\theta}$ with $\theta = 1/k$ becomes $|x^k| \geq C|x^{k+1}|^{(k-1)/k}$. Since $(k+1)(k-1)/k = k - 1/k < k$ for $k \geq 2$, this holds near $x=0$. Integrating the gradient flow $\dot{x} = -x^k$ yields polynomial convergence $|x(t)| \sim t^{-1/(k-1)}$. Arnold's classification (1972) ensures these are the only structurally stable degeneracies.
 :::
@@ -543,7 +532,6 @@ $$\mathsf{Obl}(\Gamma) \setminus \{(\mathsf{id}_P, \ldots)\} \cup \{K_P^+\}$$
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-inc-complete
 
 The NO-inconclusive certificate records an epistemic gap, not a semantic refutation (Definition {prf:ref}`def-typed-no-certificates`). When all prerequisites in $\mathsf{missing}$ are satisfied, the original predicate $P$ becomes decidable. The discharge condition (Definition {prf:ref}`def-inc-upgrades`) ensures the premises genuinely imply the obligation. The upgrade is sound because $K^{\mathrm{inc}}$ records the exact obligation and its missing prerequisites; when those prerequisites are satisfied, the original predicate $P$ holds by the discharge condition.
 :::
@@ -573,7 +561,6 @@ $$\mathrm{Cl}(\Gamma_{\mathrm{final}}) \ni K_P^+ \quad \text{(discharged from } 
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-inc-aposteriori
 
 The promotion closure iterates until fixed point. On each iteration, inc-upgrade rules (Definition {prf:ref}`def-inc-upgrades`) are applied alongside blk-promotion rules. The a-posteriori discharge is triggered when certificates from later nodes enter the closure and match the $\mathsf{missing}$ set. Termination follows from the certificate finiteness condition (Definition {prf:ref}`def-cert-finite`).
 :::

--- a/docs/source/2_hypostructure/08_upgrades/02_retroactive.md
+++ b/docs/source/2_hypostructure/08_upgrades/02_retroactive.md
@@ -53,8 +53,6 @@ $$K_{\mathrm{Rec}_N}^- \wedge K_{\mathrm{TB}_\pi}^+ \wedge K_{\text{Action}}^{\m
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-shadow-retroactive
-
 Each sector transition costs at least $\delta$ units of action/energy. With bounded total energy $E_{\max}$, at most $E_{\max}/\delta$ transitions can occur. This is the Conley index argument (1978) applied to gradient-like flows: the Morse-Conley theory bounds the number of critical point transitions by the total change in index. Combined with energy dissipation, this forbids Zeno accumulation.
 :::
 
@@ -90,8 +88,6 @@ $$K_{\text{Lock}}^{\mathrm{blk}} \Rightarrow \forall i: K_{\text{Barrier}_i}^{\m
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-lockback
-
 The morphism obstruction at the Lock is a global invariant. If no bad pattern embeds globally, then any local certificate that was "Blocked" (i.e., locally ambiguous) must resolve to "Regular" since the alternative (singular) is globally forbidden. This is the "principle of the excluded middle" applied via the universal property of the bad pattern functor.
 :::
 
@@ -129,8 +125,6 @@ $$K_{\mathrm{LS}_\sigma}^{\mathrm{stag}} \wedge K_{\text{Sym}}^+ \wedge K_{\text
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-symmetry-bridge
-
 The Goldstone theorem (1961) states that spontaneous breaking of a continuous symmetry produces massless bosons. However, if the symmetry group is *compact* and the vacuum is unique (CheckSC), the would-be Goldstones acquire mass via the Higgs mechanism or explicit breaking. The resulting spectral gap $\lambda > 0$ provides stiffness. For gauge theories, this is the mass gap conjecture; for condensed matter, this is the BCS mechanism.
 :::
 
@@ -168,8 +162,6 @@ $$K_{\mathrm{Cap}_H}^{\mathrm{blk}} \wedge K_{\mathrm{TB}_O}^+ \Rightarrow K_{\m
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-tame-smoothing
-
 In an o-minimal structure, every definable set admits a Whitney stratification into smooth manifolds (Lojasiewicz, 1965; van den Dries-Miller, 1996). A set of zero capacity is contained in a stratum of positive codimension. By the Kurdyka-Lojasiewicz inequality, the solution extends uniquely across such strata. The gradient flow cannot accumulate on a positive-codimension set.
 :::
 
@@ -207,8 +199,6 @@ $$K_{\text{sat}}^{\mathrm{blk}} \wedge K_{\mathrm{TB}_\rho}^+ \Rightarrow K_{D_E
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-ergodic
-
 The Poincare recurrence theorem (1890) states that for a measure-preserving transformation, almost every point returns arbitrarily close to its initial position. Combined with mixing (strong ergodicity), the time averages converge to the space average: $\frac{1}{T}\int_0^T \Phi(x(t)) \, dt \to \int \Phi \, d\mu$. If the invariant measure has $\mu(\Phi) < \infty$ (Saturation), recurrence to low-energy states is guaranteed.
 :::
 
@@ -244,8 +234,6 @@ $$K_{\mathrm{SC}_\lambda}^- \wedge K_{\mathrm{GC}_T}^+ \Rightarrow K_{\mathrm{SC
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-variety-control
-
 Ashby's Law of Requisite Variety (1956) states that "only variety can absorb variety." If the controller has sufficient degrees of freedom ($\log|\mathcal{U}| \geq \log|\mathcal{D}|$), it can cancel any disturbance. The Conant-Ashby theorem (1970) formalizes this: every good regulator of a system must be a model of that system. Applied to scaling instabilities, a sufficiently complex controller can inject anti-scaling corrections that neutralize supercritical growth.
 :::
 
@@ -283,8 +271,6 @@ $$K_{\mathrm{Rec}_N}^{\mathrm{blk}} \wedge K_{\mathrm{Rep}_K}^+ \Rightarrow K_{\
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-algorithm-depth
-
 Kolmogorov complexity bounds the information content of an object. If $K(x) \leq C$ for some constant $C$, then $x$ is compressible/simple. A genuinely singular object (fractal, infinitely complex) has $K(x) \to \infty$. Therefore, a Zeno singularity with finite complexity must be a coordinate artifact---like the event horizon in Schwarzschild coordinates, which disappears in Eddington-Finkelstein coordinates. Algorithmic removability follows.
 :::
 
@@ -324,8 +310,6 @@ $$K_{\mathrm{Cap}_H}^{\text{ambiguous}} \wedge K_{\mathrm{Rep}_K}^+ \Rightarrow 
 :::
 
 :::{prf:proof}
-:label: sketch-mt-up-holographic
-
 The connection between algorithmic complexity and geometric dimension is mediated by *effective Hausdorff dimension* {cite}`Lutz03`. For a set $\Sigma$, define:
 
 $$
@@ -375,8 +359,6 @@ $$K_{\mathrm{GC}_\nabla}^{\text{chaotic}} \wedge K_{\text{Lock}}^{\mathrm{blk}} 
 :::
 
 :::{prf:proof}
-:label: sketch-mt-lock-spectral-quant
-
 Weyl's law (1911) relates the spectral asymptotics $N(\lambda) \sim C\lambda^{n/2}$ to the geometry. If global invariants are quantized (integers), the spectrum is discrete: $\sigma(L) \subset \{\lambda_n\}_{n \in \mathbb{N}}$. By the Paley-Wiener theorem, functions with discrete spectrum are almost periodic. Kac's "Can one hear the shape of a drum?" (1966) shows geometry determines spectrum and vice versa.
 :::
 
@@ -423,8 +405,6 @@ where $K_{\text{Backend}}^+$ is one of:
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-unique-attractor
-
 #### Backend A: Unique Ergodicity + Discrete Attractor
 
 **Additional Hypotheses:**
@@ -621,8 +601,6 @@ $$K_{\mathrm{OGP}}^+ \wedge K_{C_\mu}^+ \wedge K_{\mu \leftarrow \mathcal{R}}^+ 
 :::
 
 :::{prf:proof}
-:label: proof-mt-up-selchi-cap
-
 *Step 1 (Correlation–Support Lemma).* Define the correlation function:
 
 $$
@@ -711,8 +689,6 @@ $$K_{C_\mu}^+ \wedge K_{\mathrm{Sel}_\chi}^+ \Rightarrow K_{\mathrm{Scope}}^+$$
 :::
 
 :::{prf:proof}
-:label: proof-mt-up-ogpchi
-
 *Step 1 (Selector Discontinuity Implies Guessing).* By $K_{\mathrm{Sel}_\chi}^+$, any algorithm $\mathcal{A}$ must transition from:
 
 $$

--- a/docs/source/2_hypostructure/08_upgrades/03_stability.md
+++ b/docs/source/2_hypostructure/08_upgrades/03_stability.md
@@ -61,7 +61,6 @@ $$
 :::
 
 :::{prf:proof}
-:label: sketch-mt-krnl-openness
 
 Strict inequalities define open sets. The Morse-Smale stability theorem (Palis and de Melo, 1982) states that structurally stable systems form an open set. The key is non-degeneracy: if all eigenvalues are strictly away from zero and all capacities are strictly bounded, small perturbations preserve these properties. This is the implicit function theorem applied to the certificate functionals.
 :::
@@ -107,7 +106,6 @@ $$
 :::
 
 :::{prf:proof}
-:label: sketch-mt-krnl-shadowing
 
 The Anosov shadowing lemma (1967) states that uniformly hyperbolic systems have the shadowing property. The spectral gap $\lambda$ controls the contraction rate, and the shadowing distance is $\delta \sim \varepsilon/\lambda$. Bowen (1975) extended this to Axiom A systems. Palmer (1988) gave a proof via the contraction mapping theorem on sequence spaces.
 :::
@@ -155,7 +153,6 @@ $$
 :::
 
 :::{prf:proof}
-:label: sketch-mt-krnl-weak-strong
 
 The weak-strong uniqueness principle uses energy estimates. If $v = u_w - u_s$, then $\frac{d}{dt}\|v\|^2 \leq C\|v\|^2 \cdot \|u_s\|_{X}$ for an appropriate norm $X$. If $u_s \in L^p([0,T]; X)$ (Serrin class), Gronwall's inequality gives $\|v(t)\| = 0$. For Navier-Stokes, $X = L^r$ with $\frac{2}{p} + \frac{3}{r} = 1$, $r > 3$ (Serrin, 1963; Lions, 1996).
 :::
@@ -209,7 +206,6 @@ $$
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-product
 
 #### Backend A: Subcritical Scaling
 
@@ -420,7 +416,6 @@ $$
 :::
 
 :::{prf:proof}
-:label: sketch-mt-krnl-subsystem
 
 If $\mathcal{S}$ developed a singularity, it would correspond to a morphism $\phi: \mathcal{B}_{\text{univ}} \to \mathcal{S} \hookrightarrow \mathcal{H}$. But this contradicts $\mathrm{Hom}(\mathcal{B}_{\text{univ}}, \mathcal{H}) = \emptyset$. The Fenichel invariant manifold theorem (1971) shows that normally hyperbolic invariant manifolds persist under perturbation; combined with Hirsch-Pugh-Shub (1977), the restriction maintains all regularity properties.
 :::

--- a/docs/source/2_hypostructure/09_mathematical/01_theorems.md
+++ b/docs/source/2_hypostructure/09_mathematical/01_theorems.md
@@ -2,6 +2,8 @@
 title: "Gate, Barrier, and Surgery Theorems"
 ---
 
+# Gate, Barrier, and Surgery Theorems
+
 (sec-gate-evaluator-theorems)=
 ## Gate Evaluator Theorems
 
@@ -44,7 +46,6 @@ $$\int_{-\infty}^0 \mathfrak{D}(v_\infty(s)) \, ds = \infty$$
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-tactic-scale
 
 *Step 1 (Change of Variables).* For rescaled time $s = \lambda_n^\beta(t - t_n)$ and rescaled state $v_n(s) = \mathcal{S}_{\lambda_n} \cdot u(t)$:
 
@@ -98,7 +99,6 @@ for some $\theta \in [1/2, 1)$ and $c > 0$.
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-spectral-gen
 
 *Step 1 (Hessian structure).* Near a critical point $x_* \in M$, the height functional $\Phi$ admits Taylor expansion:
 
@@ -152,7 +152,6 @@ The theorem makes this precise: if your system is mixing and you have finite ene
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-ergodic-mixing
 
 *Step 1 (Mixing definition).* The system is mixing if for all $f, g \in L^2(\mu)$:
 
@@ -208,7 +207,6 @@ The interface permit $\mathrm{GC}_\nabla$ (Gradient Consistency) is equivalent t
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-spectral-dist
 
 *Step 1 (Spectral triple).* A spectral triple $(\mathcal{A}, \mathcal{H}, D)$ consists of: algebra $\mathcal{A}$ acting on Hilbert space $\mathcal{H}$, self-adjoint Dirac operator $D$ with compact resolvent.
 
@@ -258,7 +256,6 @@ For the Sieve, this means boundary interactions can be measured by cut sizes. Th
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-antichain
 
 *Step 1 (Menger's theorem).* In a finite graph, the maximum flow from source to sink equals the minimum cut capacity. For causal graphs, this relates the "information flow" through time to the minimal separating surface.
 
@@ -331,7 +328,6 @@ for generator $\mathcal{L}$, constant $\lambda > 0$, bound $b < \infty$, and com
 :::
 
 :::{prf:proof}
-:label: proof-mt-up-saturation-principle
 
 *Step 1 (Generator bound).* Apply Itô's lemma to $\mathcal{V}(X_t)$:
 
@@ -397,7 +393,6 @@ $$K_{D_E}^+ \wedge (N_{\text{req}} = \infty) \Rightarrow K_{\mathrm{Rec}_N}^{\ma
 :::
 
 :::{prf:proof}
-:label: proof-mt-up-causal-barrier
 
 *Step 1 (Energy bound).* By interface permit $D_E$, the system has finite average energy $E = \int_0^T (E(t) - E_0) dt < \infty$.
 
@@ -445,7 +440,6 @@ Then **occupation time bounds** hold: the trajectory cannot spend infinite time 
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-tactic-capacity
 
 *Step 1 (Capacity-codimension bound).* By the background geometry interface permit (BG4):
 
@@ -500,7 +494,6 @@ for universal constants $C = 1$, $c = 1/8$.
 :::
 
 :::{prf:proof}
-:label: proof-mt-up-shadow
 
 *Step 1 (Herbst argument).* The log-Sobolev inequality (LSI) with constant $\lambda_{\text{LS}}$ implies concentration of measure. For any 1-Lipschitz function $f$:
 
@@ -558,7 +551,6 @@ $$\int_0^\infty \log |S(j\omega)| \, d\omega = \pi \sum_{i=1}^{n_p} p_i$$
 :::
 
 :::{prf:proof}
-:label: proof-thm-bode
 
 *Step 1 (Cauchy integral setup).* Consider the contour integral of $\log S(s)$ around the right half-plane: a semicircle from $-jR$ to $jR$ closed by the imaginary axis.
 
@@ -619,7 +611,6 @@ Information cannot increase through processing.
 :::
 
 :::{prf:proof}
-:label: proof-mt-act-horizon
 
 *Step 1 (Entropy production).* For a system with positive Lyapunov exponents $\lambda_i > 0$, Pesin's formula gives the KS entropy:
 
@@ -703,7 +694,6 @@ where $\xi$ is distributional noise (e.g., space-time white noise) and $F$ invol
 :::
 
 :::{prf:proof}
-:label: proof-mt-act-lift
 
 *Step 1 (Regularity structure).* Build an abstract polynomial-like structure that encodes:
 - Basis elements representing canonical noise terms
@@ -768,7 +758,6 @@ The procedure maintains:
 :::
 
 :::{prf:proof}
-:label: proof-mt-act-surgery-2
 
 *Step 1 (Canonical neighborhood theorem).* Near high-curvature points, the geometry is modeled by one of:
 - Shrinking round spheres $S^n$
@@ -832,7 +821,6 @@ The relaxation satisfies:
 :::
 
 :::{prf:proof}
-:label: proof-mt-act-projective
 
 *Step 1 (Slack introduction).* Replace hard constraint $g_i(x) \leq 0$ with soft constraint $g_i(x) - s_i \leq 0$ and $s_i \geq 0$. The feasible region expands.
 
@@ -889,7 +877,6 @@ The BRST construction provides:
 :::
 
 :::{prf:proof}
-:label: proof-mt-act-ghost
 
 *Step 1 (Gauge fixing).* Choose gauge-fixing function $F(A) = 0$. Insert:
 
@@ -954,7 +941,6 @@ ensures:
 :::
 
 :::{prf:proof}
-:label: proof-mt-act-align
 
 *Step 1 (KKT conditions).* At the saddle point $(x^*, \lambda^*)$:
 
@@ -1013,7 +999,6 @@ This is especially powerful in general relativity, where Penrose diagrams let yo
 :::
 
 :::{prf:proof}
-:label: proof-mt-act-compactify
 
 *Step 1 (Conformal factor construction).* Choose $\Omega$ vanishing at infinity:
 

--- a/docs/source/2_hypostructure/09_mathematical/02_algebraic.md
+++ b/docs/source/2_hypostructure/09_mathematical/02_algebraic.md
@@ -2,6 +2,8 @@
 title: "Algebraic-Geometric Unification"
 ---
 
+# Algebraic-Geometric Unification
+
 (sec-algebraic-geometric-metatheorems)=
 ## Algebraic-Geometric Metatheorems
 
@@ -42,7 +44,7 @@ Think of it this way. You have a flow on some space, and you want to understand 
 :::{prf:theorem} [LOCK-Motivic] Motivic Flow Principle
 :label: mt-lock-motivic
 
-**Sieve Signature**
+**Sieve Signature (Motivic Flow)**
 - **Requires:** $K_{D_E}^+$ (finite energy), $K_{C_\mu}^+$ (concentration), $K_{\mathrm{SC}_\lambda}^+$ (subcritical scaling)
 - **Produces:** $K_{\text{motive}}^+$ (motivic assignment with weight filtration)
 
@@ -84,7 +86,6 @@ satisfying:
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-motivic
 
 *Step 1 (Profile space construction).* The certificate $K_{C_\mu}^+$ guarantees concentration: there exists a finite-dimensional algebraic variety $\mathcal{P} \subset \text{Hilb}(X)$ such that all limit profiles lie in $\mathcal{P}/G$ where $G$ is the symmetry group. By Grothendieck's representability, $\mathcal{P}$ is a quasi-projective scheme.
 
@@ -150,7 +151,7 @@ What makes this computationally wonderful is that finding such certificates is a
 
 **Source:** Stengle's Positivstellensatz (1974)
 
-**Sieve Signature**
+**Sieve Signature (Schematic)**
 - **Requires:** $K_{\mathrm{Cap}_H}^+$ (capacity bound), $K_{\mathrm{LS}_\sigma}^+$ (Łojasiewicz gradient), $K_{\mathrm{SC}_\lambda}^+$ (subcritical scaling), $K_{\mathrm{TB}_\pi}^+$ (topological bound)
 - **Produces:** $K_{\text{SOS}}^+$ (sum-of-squares certificate witnessing Bad Pattern exclusion)
 
@@ -200,7 +201,6 @@ The original Nullstellensatz formulation applies to equalities over $\mathbb{C}$
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-schematic
 
 *Step 1 (Real algebraic geometry).* The permit certificates define polynomial inequalities over $\mathbb{R}$, not equalities over $\mathbb{C}$. Hilbert's Nullstellensatz does not apply directly to inequalities; we use the Positivstellensatz instead.
 
@@ -244,7 +244,7 @@ What we do here is connect this classical story to the sieve framework. The stif
 :::{prf:theorem} [LOCK-Kodaira] Kodaira-Spencer Stiffness Link
 :label: mt-lock-kodaira
 
-**Sieve Signature**
+**Sieve Signature (Kodaira-Spencer)**
 - **Requires:** $K_{\mathrm{LS}_\sigma}^+$ (stiffness gradient), $K_{C_\mu}^+$ (concentration on finite-dimensional moduli)
 - **Produces:** $K_{\text{KS}}^+$ (deformation cohomology, rigidity classification)
 
@@ -275,7 +275,6 @@ Consider the tangent sheaf cohomology groups $H^i(V, T_V)$ for $i = 0, 1, 2$. Th
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-kodaira
 
 *Step 1 (Deformation functor).* Define the deformation functor $\text{Def}_V: \mathbf{Art}_k \to \mathbf{Sets}$ by:
 
@@ -351,7 +350,7 @@ This is how the sieve connects to Gromov-Witten theory and Donaldson-Thomas theo
 :::{prf:theorem} [LOCK-Virtual] Virtual Cycle Correspondence
 :label: mt-lock-virtual
 
-**Sieve Signature**
+**Sieve Signature (Virtual Cycle)**
 - **Requires:** $K_{\mathrm{Cap}_H}^+$ (capacity bound on moduli), $K_{D_E}^+$ (finite energy), $K_{\mathrm{Rep}}^+$ (representation completeness)
 - **Produces:** $K_{\text{virtual}}^+$ (virtual fundamental class, enumerative invariants)
 
@@ -407,7 +406,6 @@ Then:
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-virtual
 
 *Step 1 (Obstruction theory).* A perfect obstruction theory is a morphism $\phi: \mathbb{E}^\bullet \to \mathbb{L}_{\mathcal{M}}$ in $D^{[-1,0]}(\mathcal{M})$ satisfying:
 - $h^0(\phi): h^0(\mathbb{E}^\bullet) \xrightarrow{\cong} h^0(\mathbb{L}_{\mathcal{M}}) = \Omega_{\mathcal{M}}$ is an isomorphism
@@ -463,14 +461,14 @@ What does this have to do with the sieve? The scaling exponents from $K_{\mathrm
 :::{prf:theorem} [LOCK-Hodge] Monodromy-Weight Lock
 :label: mt-lock-hodge
 
-**Rigor Class:** L (Literature-Anchored) — see {prf:ref}`def-rigor-classification`
+**Rigor Class (Monodromy-Weight):** L (Literature-Anchored) — see {prf:ref}`def-rigor-classification`
 
 **Bridge Verification:**
 1. *Hypothesis Translation:* Certificates $K_{\mathrm{TB}_\pi}^+ \wedge K_{\mathrm{SC}_\lambda}^+ \wedge K_{D_E}^+$ imply: proper flat morphism $\pi: \mathcal{X} \to \Delta$ with semistable reduction, bounded period map $\|\nabla\Pi\| \leq c$
 2. *Domain Embedding:* $\iota: \mathbf{Hypo}_T \to \mathbf{MHS}$ mapping to category of mixed Hodge structures via Deligne's construction
 3. *Conclusion Import:* Schmid's Nilpotent Orbit Theorem {cite}`Schmid73` + GAGA {cite}`Serre56` + Griffiths' Hodge Theory {cite}`Griffiths68` $\Rightarrow K_{\text{MHS}}^+$ (weight-monodromy correspondence)
 
-**Sieve Signature**
+**Sieve Signature (Monodromy-Weight)**
 - **Requires:** $K_{\mathrm{TB}_\pi}^+$ (topological bound on monodromy), $K_{\mathrm{SC}_\lambda}^+$ (subcritical scaling), $K_{D_E}^+$ (finite energy)
 - **Produces:** $K_{\text{MHS}}^+$ (limiting mixed Hodge structure, weight-monodromy correspondence)
 
@@ -510,7 +508,6 @@ Then the limiting mixed Hodge structure (MHS) satisfies:
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-hodge
 
 *Step 1 (Monodromy).* Let $T: H^k(X_t, \mathbb{Z}) \to H^k(X_t, \mathbb{Z})$ be the monodromy operator for a loop $\gamma$ around $0$. The certificate $K_{\mathrm{TB}_\pi}^+$ ensures $\|\nabla\Pi\|$ is bounded, which by Borel's theorem implies $T$ is quasi-unipotent:
 $$(T^m - I)^{k+1} = 0 \quad \text{for some } m \geq 1$$
@@ -568,14 +565,14 @@ The motivic Galois group, which conjecturally controls all the algebraic relatio
 :::{prf:theorem} [LOCK-Tannakian] Tannakian Recognition Principle
 :label: mt-lock-tannakian
 
-**Rigor Class:** L (Literature-Anchored) — see {prf:ref}`def-rigor-classification`
+**Rigor Class (Tannakian):** L (Literature-Anchored) — see {prf:ref}`def-rigor-classification`
 
 **Bridge Verification:**
 1. *Hypothesis Translation:* Certificates $K_{\mathrm{Cat}_{\mathrm{Hom}}}^+ \wedge K_{\Gamma}^+$ imply: neutral Tannakian category $\mathcal{C}$ over $k$ with exact faithful tensor-preserving fiber functor $\omega$
 2. *Domain Embedding:* $\iota: \mathbf{Hypo}_T \to \mathbf{TannCat}_k$ mapping to category of Tannakian categories via forgetful functor
 3. *Conclusion Import:* Deligne's Tannakian Duality {cite}`Deligne90` $\Rightarrow K_{\text{Tann}}^+$ (group scheme $G = \underline{\text{Aut}}^\otimes(\omega)$ recoverable, $\mathcal{C} \simeq \text{Rep}_k(G)$)
 
-**Sieve Signature**
+**Sieve Signature (Tannakian)**
 - **Requires:** $K_{\mathrm{Cat}_{\mathrm{Hom}}}^+$ (Hom-functor structure), $K_{\Gamma}^+$ (full context certificate)
 - **Produces:** $K_{\text{Tann}}^+$ (Galois group reconstruction, algebraicity criterion, lock exclusion)
 
@@ -617,7 +614,6 @@ Then:
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-tannakian
 
 *Step 1 (Tannakian axioms).* The certificate $K_{\mathrm{Cat}_{\mathrm{Hom}}}^+$ ensures $\mathcal{C}$ satisfies the Tannakian axioms:
 - **Abelian:** $\mathcal{C}$ is a $k$-linear abelian category
@@ -676,14 +672,14 @@ This is the holographic principle from physics, translated into the sieve langua
 :::{prf:theorem} [LOCK-Capacity] Holographic Capacity Lock
 :label: mt-lock-entropy
 
-**Rigor Class:** L (Literature-Anchored) — see {prf:ref}`def-rigor-classification`
+**Rigor Class (Holographic):** L (Literature-Anchored) — see {prf:ref}`def-rigor-classification`
 
 **Bridge Verification:**
 1. *Hypothesis Translation:* Certificates $K_{\mathrm{Cap}_H}^+ \wedge K_{\mathrm{TB}_\pi}^+$ imply: bounded boundary channel capacity $C(\partial\mathcal{X})$
 2. *Domain Embedding:* $\iota: \mathbf{Hypo}_T \to \mathbf{InfoGeom}$ mapping to information-theoretic channel model $X \to Y \to Z$
 3. *Conclusion Import:* Shannon's Channel Coding Theorem {cite}`Shannon48` + Data Processing Inequality {cite}`CoverThomas06` $\Rightarrow K_{\text{Holo}}^+$ (bulk information retrieval bounded by boundary capacity)
 
-**Sieve Signature**
+**Sieve Signature (Holographic)**
 - **Requires:** $K_{\mathrm{Cap}_H}^+$ (capacity certificate), $K_{\mathrm{TB}_\pi}^+$ (topological bound)
 - **Produces:** $K_{\text{Holo}}^+$ (holographic capacity certificate, information-theoretic lock)
 
@@ -709,8 +705,7 @@ Then the **Data Processing Inequality** provides an information-theoretic lock:
 **Literature:** {cite}`Shannon48`; {cite}`CoverThomas06`; {cite}`Levin73`
 :::
 
-:::{prf:proof} Proof Sketch
-:label: sketch-mt-lock-entropy
+:::{prf:proof}
 
 *Step 1 (Data Processing Inequality).* Consider the Markov chain $X \to Y \to Z$, where $X$ is the bulk state, $Y$ is the boundary state, and $Z$ is the observer's measurement. The Data Processing Inequality states that $I(X; Z) \leq I(X; Y)$.
 
@@ -758,11 +753,11 @@ This is why the sieve works. Not because it tries all possibilities, which would
 :::{prf:theorem} [LOCK-Reconstruction] Structural Reconstruction Principle
 :label: mt-lock-reconstruction
 
-**Rigor Class:** F (Framework-Original) — see {prf:ref}`def-rigor-classification`
+**Rigor Class (Reconstruction):** F (Framework-Original) — see {prf:ref}`def-rigor-classification`
 
 This metatheorem is the "Main Result" of the framework: it proves that **Stiff** (Analytic) + **Tame** (O-minimal) systems *must* admit a representation in the structural category $\mathcal{S}$. The Łojasiewicz-Simon inequality restricts the "Moduli of Failure" so severely that only structural objects (algebraic cycles/solitons) remain.
 
-**Sieve Signature**
+**Sieve Signature (Reconstruction)**
 - **Requires:**
   - $K_{D_E}^+$ (finite energy bound on state space)
   - $K_{C_\mu}^+$ (concentration on finite-dimensional profile space)
@@ -924,7 +919,6 @@ Given the tactic trace from $K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{br\text{-}
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-reconstruction
 
 *Step 1 (Breached-inconclusive certificate analysis).* The certificate $K_{\mathrm{Cat}_{\mathrm{Hom}}}^{\mathrm{br\text{-}inc}}$ records that tactics E1-E12 have been exhausted at Node 17 without determining whether $\text{Hom}_{\mathcal{A}}(\mathcal{H}_{\text{bad}}, \mathcal{X}) = \emptyset$. The upstream certificates $K_{D_E}^+$, $K_{C_\mu}^+$, $K_{\mathrm{SC}_\lambda}^+$, $K_{\mathrm{LS}_\sigma}^+$ provide **partial progress data**:
 
@@ -1201,7 +1195,7 @@ The beautiful thing is that each step uses a different piece of the certificate 
 :::{prf:lemma} Analytic-Algebraic Rigidity
 :label: lem-analytic-algebraic-rigidity
 
-**Sieve Signature**
+**Sieve Signature (Analytic-Algebraic)**
 - **Requires:**
   - $K_{D_E}^+$ (finite energy: $\|\eta\|_{L^2}^2 < \infty$)
   - $K_{\mathrm{LS}_\sigma}^+$ (stiffness: spectral gap $\lambda > 0$ on Hodge-Riemann pairing)

--- a/docs/source/2_hypostructure/09_mathematical/03_cross_reference.md
+++ b/docs/source/2_hypostructure/09_mathematical/03_cross_reference.md
@@ -2,6 +2,8 @@
 title: "Foundation-Sieve Cross-Reference"
 ---
 
+# Foundation-Sieve Cross-Reference
+
 (sec-foundation-sieve-cross-reference)=
 ## Foundation - Sieve Cross-Reference
 

--- a/docs/source/2_hypostructure/09_mathematical/04_taxonomy.md
+++ b/docs/source/2_hypostructure/09_mathematical/04_taxonomy.md
@@ -2,6 +2,8 @@
 title: "Taxonomy of Dynamical Complexity"
 ---
 
+# Taxonomy of Dynamical Complexity
+
 (sec-taxonomy-dynamical-complexity)=
 ## The Taxonomy of Dynamical Complexity
 
@@ -550,8 +552,6 @@ where $\sim$ denotes equivalence of certificate types at each node.
 :::
 
 :::{prf:proof}
-:label: proof-thm-meta-identifiability
-:nonumber:
 
 **Outline:**
 
@@ -658,8 +658,6 @@ The proof strategy for any dynamical system is determined by its location in the
 :::
 
 :::{prf:proof}
-:label: proof-mt-lock-periodic
-:nonumber:
 
 **Outline:**
 
@@ -836,7 +834,6 @@ $$
 :::
 
 :::{prf:proof}
-:label: proof-thm-sieve-thermo-correspondence
 
 We establish the correspondence in four steps.
 

--- a/docs/source/2_hypostructure/09_mathematical/04_taxonomy.md
+++ b/docs/source/2_hypostructure/09_mathematical/04_taxonomy.md
@@ -804,7 +804,7 @@ For fixed $s$, this measures the intrinsic computational "work" required to prod
 | Intermediate | $d_s = \text{superpolynomial}$ | $K = \Theta(n^\alpha)$ | Complex but structured | May be c.e. |
 | Deep | $d_s = \Omega(2^{K})$ | $K \geq n - O(1)$ | Random, incompressible | Undecidable |
 
-**Thermodynamic Analogy:** Depth plays the role of "thermodynamic depth" (entropy production). Shallow strings are "thermodynamically cheap" to produce; deep strings require extensive irreversible computation {cite}`Bennett88; LloydPagels88`.
+**Thermodynamic Analogy:** Depth plays the role of "thermodynamic depth" (entropy production). Shallow strings are "thermodynamically cheap" to produce; deep strings require extensive irreversible computation {cite}`Bennett88,LloydPagels88`.
 
 **Note:** Unlike physical temperature, there is no canonical "algorithmic temperature" in AIT. The depth serves as the thermodynamic analog.
 :::
@@ -840,7 +840,7 @@ $$
 
 We establish the correspondence in four steps.
 
-**Step 1 (Coding Theorem):** By the Levin-Schnorr Theorem {cite}`Levin73b; Schnorr73`, the algorithmic probability $m(x) := \sum_{p: U(p)=x} 2^{-|p|}$ satisfies:
+**Step 1 (Coding Theorem):** By the Levin-Schnorr Theorem {cite}`Levin73b,Schnorr73`, the algorithmic probability $m(x) := \sum_{p: U(p)=x} 2^{-|p|}$ satisfies:
 
 $$
 -\log m(x) = K(x) + O(1)

--- a/docs/source/2_hypostructure/09_mathematical/05_algorithmic.md
+++ b/docs/source/2_hypostructure/09_mathematical/05_algorithmic.md
@@ -477,7 +477,7 @@ $((\sharp\text{-status}, \int\text{-status}, \flat\text{-status}, \ast\text{-sta
 
 By the Sieve-Thermodynamic Correspondence ({prf:ref}`thm-sieve-thermo-correspondence`), polynomial-time convergence requires **Kolmogorov complexity reduction**: the algorithm must decrease $K(x_t)$ ({prf:ref}`def-kolmogorov-complexity`) from the initial instance complexity $K(\mathcal{X}) \sim N$ to $O(\log N)$ (solution encoding) in $\text{poly}(N)$ steps.
 
-By the **Levin-Schnorr Theorem** {cite}`Levin73b; Schnorr73`, uniform random search on an amorphous (structureless) space achieves expected complexity reduction:
+By the **Levin-Schnorr Theorem** {cite}`Levin73b,Schnorr73`, uniform random search on an amorphous (structureless) space achieves expected complexity reduction:
 
 $$\mathbb{E}[\Delta K] = O(1/|\mathcal{X}|) = O(2^{-N})$$
 

--- a/docs/source/2_hypostructure/09_mathematical/05_algorithmic.md
+++ b/docs/source/2_hypostructure/09_mathematical/05_algorithmic.md
@@ -467,9 +467,7 @@ $((\sharp\text{-status}, \int\text{-status}, \flat\text{-status}, \ast\text{-sta
 **Literature:** Cohesive $(\infty,1)$-topoi {cite}`SchreiberCohesive`; Synthetic Differential Geometry {cite}`Kock06`; Axiomatic Cobordism {cite}`Lurie09TFT`; Computational Complexity {cite}`AroraBorak09`.
 ::::
 
-:::{prf:proof}
-:label: proof-mt-alg-complete
-:nonumber:
+:::{prf:proof} Proof of {prf:ref}`mt-alg-complete`
 
 **Proof (Following Categorical Proof Template — Topos Internal Logic):**
 
@@ -686,8 +684,7 @@ The domain embedding $\iota: \mathbf{Hypo}_{T_{\text{alg}}} \to \mathbf{DTM}$ is
 $$\forall M \in P.\, \exists \mathbb{H} \in \mathbf{Hypo}_{T_{\text{alg}}}.\, \iota(\mathbb{H}) \cong M$$
 :::
 
-:::{prf:proof}
-:label: proof-cor-alg-embedding-surj
+:::{prf:proof} Proof of {prf:ref}`cor-alg-embedding-surj`
 
 By MT-AlgComplete, every polynomial algorithm factors through a modality. Each modality corresponds to a structural resource representable in $\mathbf{Hypo}_{T_{\text{alg}}}$. The embedding $\iota$ is constructed to preserve these resources.
 :::
@@ -734,8 +731,8 @@ The algorithmic completeness framework is **verifiable** through the following c
 | Component | Status | Reference |
 |-----------|--------|-----------|
 | Cohesive modalities exhaust structure | **THEOREM** (Schreiber) | {prf:ref}`thm-schreiber-structure` |
-| Polynomial-time requires structure | **THEOREM** (information-theoretic) | Proof Step 1 in {prf:ref}`proof-mt-alg-complete` |
-| Structure = modal factorization | **THEOREM** (topos-theoretic) | Proof Step 2 in {prf:ref}`proof-mt-alg-complete` |
+| Polynomial-time requires structure | **THEOREM** (information-theoretic) | Proof of {prf:ref}`mt-alg-complete`, Step 1 |
+| Structure = modal factorization | **THEOREM** (topos-theoretic) | Proof of {prf:ref}`mt-alg-complete`, Step 2 |
 | MT-AlgComplete | **THEOREM** (conditional) | {prf:ref}`mt-alg-complete` |
 | Obstruction certificates | **COMPUTABLE** | {prf:ref}`def-obstruction-certificates` |
 | Bridge to DTM complexity | **THEOREM** | Part XX (Complexity Bridge) |

--- a/docs/source/2_hypostructure/09_mathematical/06_complexity_bridge.md
+++ b/docs/source/2_hypostructure/09_mathematical/06_complexity_bridge.md
@@ -55,7 +55,6 @@ The key insight is that both are counting the same thing: *how much information 
 The definitions below make this precise. Pay attention to the **CostCert** predicate—this is the bridge hinge. It is what lets us say "this hypostructure program runs in polynomial time" in a way that a classical complexity theorist can verify in ZFC.
 :::
 
-(def-effective-programs-fragile)=
 ### D0.1 Effective Programs (Fragile)
 
 :::{prf:definition} Effective Programs
@@ -84,7 +83,6 @@ $$
 This evaluator is the operational semantics of the hypostructure computational model.
 :::
 
-(def-cost-certificate)=
 ### D0.2 Cost Certificate (The Bridge Hinge)
 
 :::{prf:definition} Cost Certificate
@@ -132,7 +130,6 @@ The bridge theorems *prove* these coincide. The definitions are independent; the
 The cost certificate is analogous to a type derivation in a type system: it is a *witness* that the program has a certain property (polynomial-time), checkable independently of running the program.
 :::
 
-(def-np-fragile)=
 ### D0.3 NP in Fragile Form (Verifier + Witness)
 
 :::{prf:definition} NP (Fragile Model)
@@ -188,7 +185,6 @@ Think of them as building a two-lane bridge. The first lane (Theorems I and III)
 Once both lanes are built, we have a true equivalence. And *that* is what lets us export the separation.
 :::
 
-(thm-bridge-p-dtm-to-fragile)=
 ### Theorem I: P-Bridge (DTM → Fragile P)
 
 :::{prf:theorem} Bridge P: DTM → Fragile
@@ -269,7 +265,6 @@ This is why the forward bridge is easy. The hard direction is the reverse bridge
 
 ---
 
-(thm-extraction-p-fragile-to-dtm)=
 ### Theorem II: P-Extraction (Fragile P → DTM P)
 
 :::{prf:theorem} Extraction P: Fragile → DTM (Adequacy)
@@ -397,7 +392,6 @@ Once **(A2)** is verified, the extraction theorem follows mechanically.
 
 ---
 
-(thm-bridge-np-dtm-to-fragile)=
 ### Theorem III: NP-Bridge (DTM NP → Fragile NP)
 
 :::{prf:theorem} Bridge NP: DTM → Fragile
@@ -476,7 +470,6 @@ The beauty of the verifier characterization of NP is that it separates the hard 
 
 ---
 
-(thm-extraction-np-fragile-to-dtm)=
 ### Theorem IV: NP-Extraction (Fragile NP → DTM NP)
 
 :::{prf:theorem} Extraction NP: Fragile → DTM

--- a/docs/source/2_hypostructure/10_metalearning/01_metalearning.md
+++ b/docs/source/2_hypostructure/10_metalearning/01_metalearning.md
@@ -536,7 +536,6 @@ $$
 $$
 
 :::{prf:proof}
-:label: proof-no-melt-sketch
 
 By the EVI (Evolution Variational Inequality, Theorem {prf:ref}`thm-rcd-dissipation-link`):
 
@@ -3628,7 +3627,6 @@ $$[T^*] = [\mathbb{H}]$$
 #### Full Proof
 
 :::{prf:proof}
-:label: proof-epistemic-fixed-point
 
 **Step 1 (Bayesian Update).** By Bayes' theorem, the posterior after observing $\mathcal{D}_t$ is:
 $$\rho_t(T) = \frac{P(\mathcal{D}_t \mid T) \cdot \pi_0(T)}{\sum_{T' \in \mathfrak{T}} P(\mathcal{D}_t \mid T') \cdot \pi_0(T')}$$

--- a/docs/source/2_hypostructure/11_appendices/01_zfc.md
+++ b/docs/source/2_hypostructure/11_appendices/01_zfc.md
@@ -5,9 +5,6 @@ title: "Set-Theoretic Foundation"
 (sec-zfc-translation)=
 # The Set-Theoretic Foundation
 
-(sec-zfc-translation-layer)=
-## The ZFC Translation Layer
-
 :::{div} feynman-prose
 Now, here is a question you might reasonably ask: why bother with all this fancy topos theory if we are just going to translate everything back to ordinary set theory anyway?
 
@@ -31,7 +28,7 @@ The bridge is intentionally **semantic** rather than a term-by-term proof compil
 4. **Emit a Bridge Certificate** $\mathcal{B}_{\text{ZFC}}$ ({ref}`Cross-Foundation Audit <sec-zfc-cross-foundation-audit>`).
 
 (sec-zfc-universe-anchoring)=
-### Grothendieck Universes and Size Consistency
+## Grothendieck Universes and Size Consistency
 
 :::{div} feynman-prose
 Before we get into the technical details, let me tell you what problem we are solving. In set theory, there is a fundamental issue with "size." You cannot have a set of all sets---that leads to Russell's paradox. But in category theory, we constantly want to talk about "the category of all groups" or "the category of all topological spaces." These are proper classes, not sets.
@@ -84,7 +81,7 @@ By the accessibility of $\mathcal{E}$, all small colimits exist and are computed
 :::
 
 (sec-zfc-truncation)=
-### The Truncation Functor: $\tau_0$
+## The Truncation Functor: $\tau_0$
 
 :::{div} feynman-prose
 Here is the central operation of the whole translation layer. We have these beautiful, complicated $\infty$-groupoids with paths, paths between paths, symmetries, and coherence data stacked infinitely high. And we need to extract a plain old set that a classical mathematician can work with.
@@ -162,7 +159,7 @@ The 0-truncation functor preserves the essential structure of certificates:
 :::
 
 (sec-zfc-discrete-reflection)=
-### The Discrete Reflection Adjunction
+## The Discrete Reflection Adjunction
 
 :::{div} feynman-prose
 Let me make sure you understand what the flat modality $\flat$ is doing. It is embedding ordinary sets---the kind you learn about in a first course on set theory---into our fancy topos, as "discrete" objects with no interesting topology or homotopy.
@@ -223,7 +220,7 @@ Certificates are 0-truncated by construction (they encode Boolean decisions, fin
 :::
 
 (sec-zfc-sieve-axiom-mapping)=
-### Sieve-to-Set Axiom Mapping
+## Sieve-to-Set Axiom Mapping
 
 :::{div} feynman-prose
 Now we come to the dictionary. Each of the 17 nodes in the Sieve does something specific---it checks an energy bound, or verifies a compactness property, or confirms a scaling law. And each of these operations, when you strip away the categorical language, corresponds to using certain ZFC axioms.
@@ -287,7 +284,7 @@ Each node's interface permit specifies finite-complexity predicates on the input
 :::
 
 (sec-zfc-ac-dependency)=
-### Axiom of Choice Dependency Analysis
+## Axiom of Choice Dependency Analysis
 
 :::{div} feynman-prose
 The Axiom of Choice is special. It is the one ZFC axiom that lets you make infinitely many arbitrary selections at once, without any rule or algorithm to guide the choices. And this matters---if your proof uses Choice, then you cannot extract a computer program from it. The witness exists, but you cannot compute it.
@@ -340,7 +337,7 @@ Sieve nodes are classified by their dependence on the Axiom of Choice:
 :::
 
 (sec-zfc-cross-foundation-audit)=
-### Metatheorem: The Cross-Foundation Audit
+## Metatheorem: The Cross-Foundation Audit
 
 :::{div} feynman-prose
 This is the main theorem of the chapter. It says: if the Sieve produces a blocked certificate at the Lock (Node 17), then there exists a first-order ZFC formula that is true in our universe and that implies regularity.
@@ -352,7 +349,7 @@ The Bridge Certificate $\mathcal{B}_{\text{ZFC}}$ is the audit packet. It contai
 Note what this theorem does *not* claim: it does not say that a classical mathematician can *reproduce* the proof in ZFC. The proof uses categorical methods essentially. What it says is that the *conclusion* is ZFC-verifiable. The difference is crucial: we are not claiming ZFC is sufficient for the proofs, only that it is sufficient for the auditing.
 :::
 
-::::{prf:theorem} [KRNL-ZFC-Bridge] The Cross-Foundation Audit
+:::{prf:theorem} [KRNL-ZFC-Bridge] The Cross-Foundation Audit
 :label: mt-krnl-zfc-bridge
 
 **Statement:** Let $\mathcal{E}$ be a universe-anchored cohesive $(\infty,1)$-topos with universe $\mathcal{U}$. For any problem type $T \in \mathbf{ProbTypes}$ and concrete hypostructure $\mathbb{H}(Z)$ representing input $Z$:
@@ -433,10 +430,10 @@ $$
 By construction, $V_\mathcal{U} \vDash \varphi$ (the truncated Hom-set is empty in the universe), and $\varphi \Rightarrow \text{Reg}(Z)$ by Step 4.
 
 **Literature:** {cite}`Lurie09` (Higher Topos Theory); {cite}`Johnstone02` (internal logic of topoi); {cite}`Jech03` (ZFC set theory); {cite}`MacLaneMoerdijk92` (topos-set correspondence).
-::::
+:::
 
 (sec-zfc-epistemic-summary)=
-### Epistemic Summary
+## Epistemic Summary
 
 The ZFC Translation Layer establishes a formal bridge between the categorical machinery of the Hypostructure Formalism and classical set-theoretic foundations.
 
@@ -480,7 +477,7 @@ Working in $\mathcal{E}$ provides natural handling of homotopical structure, gau
 :::
 
 (sec-zfc-axiomatic-dictionary)=
-### Axiomatic Dictionary: ZFC to Hypostructure Mapping
+## Axiomatic Dictionary: ZFC to Hypostructure Mapping
 
 :::{div} feynman-prose
 Here is where we lay out the complete dictionary between ZFC and topos theory. Every axiom of ZFC has a categorical counterpart, and understanding these correspondences is essential for trusting the translation.
@@ -572,7 +569,7 @@ The mapping $\mathcal{M}: \text{ZFC} \to \mathcal{E}$ is defined by the followin
 :::
 
 (sec-zfc-classicality)=
-### The Classicality Operator: Heyting vs Boolean Logic
+## The Classicality Operator: Heyting vs Boolean Logic
 
 :::{div} feynman-prose
 Here is a subtlety that trips up many people. The internal logic of a topos is *intuitionistic*: you cannot assume that every proposition is either true or false. The Law of Excluded Middle ($P \vee \neg P$) is not a theorem.
@@ -644,7 +641,7 @@ For the Sieve, a certificate $K$ is **classically valid** if $\delta(\tau_0(K)) 
 :::
 
 (sec-zfc-internal-external-choice)=
-### Internal vs External Choice
+## Internal vs External Choice
 
 :::{div} feynman-prose
 There are two versions of the Axiom of Choice, and confusing them is a common error.
@@ -713,7 +710,7 @@ Sieve nodes are classified by their choice requirements:
 :::
 
 (sec-zfc-universe-level-tracking)=
-### Universe Level Tracking
+## Universe Level Tracking
 
 To prevent "size-shifting" errors where proper classes are treated as sets, explicit universe stratification is required.
 
@@ -757,7 +754,7 @@ Each Sieve node performs operations (pullback, pushout, hom-evaluation) that are
 :::
 
 (sec-zfc-translation-residual)=
-### The Translation Residual
+## The Translation Residual
 
 :::{div} feynman-prose
 When we apply $\tau_0$, we throw away the higher homotopy groups: $\pi_1$ (gauge symmetries), $\pi_2$ (coherence conditions), and everything beyond. This is the "residual"---the information that does not survive the translation.
@@ -811,7 +808,7 @@ While certificates have zero residual, **intermediate constructions** in proofs 
 :::
 
 (sec-zfc-stack-set-divergence)=
-### Stack-Set Divergence
+## Stack-Set Divergence
 
 :::{div} feynman-prose
 Here is a trap that catches even experienced mathematicians. A stack (or groupoid, or higher groupoid) is *not* a set with extra structure. It is a fundamentally different kind of object, and reasoning about it as if it were a set leads to errors.
@@ -858,7 +855,7 @@ The translation layer detects this when the set-level projection silently assume
 :::
 
 (sec-zfc-descent-logic)=
-### Descent Logic and Size Constraints
+## Descent Logic and Size Constraints
 
 Grothendieck descent provides the mechanism for "gluing" local set-theoretic constructions into global categorical objects.
 
@@ -900,7 +897,7 @@ This follows from the closure properties of Grothendieck universes under the ope
 :::
 
 (sec-zfc-consistency-invariant)=
-### The Consistency Invariant
+## The Consistency Invariant
 
 The ZFC Translation Layer satisfies a fundamental consistency property: valid categorical proofs yield consistent set-theoretic projections.
 
@@ -950,7 +947,7 @@ An infinite $\prec$-descending sequence in $S$ would define an infinite descendi
 :::
 
 (sec-zfc-fundamental-theorem)=
-### The Fundamental Theorem of Set-Theoretic Reflection
+## The Fundamental Theorem of Set-Theoretic Reflection
 
 :::{div} feynman-prose
 This is the culmination of everything. We have built all the machinery---the truncation functor, the discrete reflection, the axiom dictionary, the classicality analysis. Now we put it together into one theorem that says: the internal truth of "$\operatorname{Hom}(\mathbb{H}_{\text{bad}}, \mathbb{H}) \simeq \emptyset$" in the topos implies the external truth of "every point in $\tau_0(\mathcal{X})$ is regular" in ZFC.

--- a/docs/source/2_hypostructure/intro_hypostructure.md
+++ b/docs/source/2_hypostructure/intro_hypostructure.md
@@ -72,7 +72,7 @@ The **Algorithmic Representation Theorem (MT-AlgComplete)** proves these five cl
 Bidirectional bridge theorems establish $P_{\text{Fragile}} = P_{\text{DTM}}$ and $NP_{\text{Fragile}} = NP_{\text{DTM}}$, allowing internal complexity separations to export to classical ZFC statements about P and NP. The framework reduces the P vs NP question to concrete geometric/topological properties of energy landscapes.
 
 **Meta-Learning Extension:**
-The axioms themselves can be *learned* as the solution to a constrained optimization problem over defect functionals. See {doc}`source/2_hypostructure/10_metalearning/01_metalearning`.
+The axioms themselves can be *learned* as the solution to a constrained optimization problem over defect functionals. See {doc}`2_hypostructure/10_metalearning/01_metalearning`.
 
 **Why "Hypostructure"?**
 A hypostructure is an object carrying *surgery-resolution data*—the information needed to repair singularities if they occur. The term emphasizes that we are not just detecting problems but providing certified repair mechanisms.
@@ -106,17 +106,17 @@ A hypostructure is an object carrying *surgery-resolution data*—the informatio
 - Cobordism theory for surgery operations
 
 **Quick Navigation:**
-- *Want the categorical foundations?* → {doc}`source/2_hypostructure/01_foundations/01_categorical`
-- *Want the axiom system?* → {doc}`source/2_hypostructure/02_axioms/01_axiom_system`
-- *Want the kernel and certificates?* → {doc}`source/2_hypostructure/03_sieve/02_kernel`
-- *Want gate node specifications?* → {doc}`source/2_hypostructure/04_nodes/01_gate_nodes`
-- *Want factory metatheorems?* → {doc}`source/2_hypostructure/07_factories/01_metatheorems`
-- *Want upgrade theorems?* → {doc}`source/2_hypostructure/08_upgrades/01_instantaneous`
-- *Want mathematical foundations?* → {doc}`source/2_hypostructure/09_mathematical/01_theorems`
-- *Want algorithmic completeness theory?* → {doc}`source/2_hypostructure/09_mathematical/05_algorithmic`
-- *Want P/NP complexity bridge?* → {doc}`source/2_hypostructure/09_mathematical/06_complexity_bridge`
-- *Want meta-learning?* → {doc}`source/2_hypostructure/10_metalearning/01_metalearning`
-- *Want ZFC translation?* → {doc}`source/2_hypostructure/11_appendices/01_zfc`
+- *Want the categorical foundations?* → {doc}`2_hypostructure/01_foundations/01_categorical`
+- *Want the axiom system?* → {doc}`2_hypostructure/02_axioms/01_axiom_system`
+- *Want the kernel and certificates?* → {doc}`2_hypostructure/03_sieve/02_kernel`
+- *Want gate node specifications?* → {doc}`2_hypostructure/04_nodes/01_gate_nodes`
+- *Want factory metatheorems?* → {doc}`2_hypostructure/07_factories/01_metatheorems`
+- *Want upgrade theorems?* → {doc}`2_hypostructure/08_upgrades/01_instantaneous`
+- *Want mathematical foundations?* → {doc}`2_hypostructure/09_mathematical/01_theorems`
+- *Want algorithmic completeness theory?* → {doc}`2_hypostructure/09_mathematical/05_algorithmic`
+- *Want P/NP complexity bridge?* → {doc}`2_hypostructure/09_mathematical/06_complexity_bridge`
+- *Want meta-learning?* → {doc}`2_hypostructure/10_metalearning/01_metalearning`
+- *Want ZFC translation?* → {doc}`2_hypostructure/11_appendices/01_zfc`
 :::
 
 (sec-hypo-how-to-read)=
@@ -143,15 +143,15 @@ This formalism is designed to be **modular**. Each part is written to be as self
 
 | If you want...                    | Read...                                  | Dependencies                          |
 |-----------------------------------|------------------------------------------|---------------------------------------|
-| Categorical foundations only      | {doc}`Part I <source/2_hypostructure/01_foundations/01_categorical>` | Basic category theory                 |
-| The axiom system                  | {doc}`Part II <source/2_hypostructure/02_axioms/01_axiom_system>` | Part I helpful but not required       |
-| Gate/barrier/surgery specs        | {doc}`Part IV <source/2_hypostructure/04_nodes/01_gate_nodes>`, {doc}`Part V <source/2_hypostructure/05_interfaces/01_gate_evaluator>` | Part III for certificate semantics    |
-| Factory metatheorems              | {doc}`Part VII <source/2_hypostructure/07_factories/01_metatheorems>` | Parts III-V for context               |
-| Upgrade theorems (Thin → Full)    | {doc}`Part VIII <source/2_hypostructure/08_upgrades/01_instantaneous>` | Parts III-IV for certificate types    |
-| Algorithmic completeness          | {doc}`Part XIX <source/2_hypostructure/09_mathematical/05_algorithmic>` | Part I for modalities                 |
-| P/NP complexity bridge            | {doc}`Part XX <source/2_hypostructure/09_mathematical/06_complexity_bridge>` | Part XIX for algorithm classes        |
-| Meta-learning axioms              | {doc}`Part X <source/2_hypostructure/10_metalearning/01_metalearning>` | Can standalone with Part II summary   |
-| ZFC translation                   | {doc}`Part XI <source/2_hypostructure/11_appendices/01_zfc>` | Can standalone                        |
+| Categorical foundations only      | {doc}`Part I <2_hypostructure/01_foundations/01_categorical>` | Basic category theory                 |
+| The axiom system                  | {doc}`Part II <2_hypostructure/02_axioms/01_axiom_system>` | Part I helpful but not required       |
+| Gate/barrier/surgery specs        | {doc}`Part IV <2_hypostructure/04_nodes/01_gate_nodes>`, {doc}`Part V <2_hypostructure/05_interfaces/01_gate_evaluator>` | Part III for certificate semantics    |
+| Factory metatheorems              | {doc}`Part VII <2_hypostructure/07_factories/01_metatheorems>` | Parts III-V for context               |
+| Upgrade theorems (Thin → Full)    | {doc}`Part VIII <2_hypostructure/08_upgrades/01_instantaneous>` | Parts III-IV for certificate types    |
+| Algorithmic completeness          | {doc}`Part XIX <2_hypostructure/09_mathematical/05_algorithmic>` | Part I for modalities                 |
+| P/NP complexity bridge            | {doc}`Part XX <2_hypostructure/09_mathematical/06_complexity_bridge>` | Part XIX for algorithm classes        |
+| Meta-learning axioms              | {doc}`Part X <2_hypostructure/10_metalearning/01_metalearning>` | Can standalone with Part II summary   |
+| ZFC translation                   | {doc}`Part XI <2_hypostructure/11_appendices/01_zfc>` | Can standalone                        |
 
 ### LLM-Assisted Exploration
 
@@ -173,61 +173,61 @@ A recommended approach for understanding this framework:
 ## Book Map
 
 **Part I: Categorical Foundations**
-- {doc}`source/2_hypostructure/01_foundations/01_categorical`
-- {doc}`source/2_hypostructure/01_foundations/02_constructive`
+- {doc}`2_hypostructure/01_foundations/01_categorical`
+- {doc}`2_hypostructure/01_foundations/02_constructive`
 
 **Part II: Axiom System**
-- {doc}`source/2_hypostructure/02_axioms/01_axiom_system`
+- {doc}`2_hypostructure/02_axioms/01_axiom_system`
 
 **Part III: The Sieve**
-- {doc}`source/2_hypostructure/03_sieve/01_structural`
-- {doc}`source/2_hypostructure/03_sieve/02_kernel`
+- {doc}`2_hypostructure/03_sieve/01_structural`
+- {doc}`2_hypostructure/03_sieve/02_kernel`
 
 **Part IV: Node Specifications**
-- {doc}`source/2_hypostructure/04_nodes/01_gate_nodes`
-- {doc}`source/2_hypostructure/04_nodes/02_barrier_nodes`
-- {doc}`source/2_hypostructure/04_nodes/03_surgery_nodes`
+- {doc}`2_hypostructure/04_nodes/01_gate_nodes`
+- {doc}`2_hypostructure/04_nodes/02_barrier_nodes`
+- {doc}`2_hypostructure/04_nodes/03_surgery_nodes`
 
 **Part V: Soft Interfaces**
-- {doc}`source/2_hypostructure/05_interfaces/01_gate_evaluator`
-- {doc}`source/2_hypostructure/05_interfaces/02_permits`
-- {doc}`source/2_hypostructure/05_interfaces/03_contracts`
+- {doc}`2_hypostructure/05_interfaces/01_gate_evaluator`
+- {doc}`2_hypostructure/05_interfaces/02_permits`
+- {doc}`2_hypostructure/05_interfaces/03_contracts`
 
 **Part VI: Singularity Modules**
-- {doc}`source/2_hypostructure/06_modules/01_singularity`
-- {doc}`source/2_hypostructure/06_modules/02_equivalence`
-- {doc}`source/2_hypostructure/06_modules/03_lock`
+- {doc}`2_hypostructure/06_modules/01_singularity`
+- {doc}`2_hypostructure/06_modules/02_equivalence`
+- {doc}`2_hypostructure/06_modules/03_lock`
 
 **Part VII: Factory Metatheorems**
-- {doc}`source/2_hypostructure/07_factories/01_metatheorems`
-- {doc}`source/2_hypostructure/07_factories/02_instantiation`
+- {doc}`2_hypostructure/07_factories/01_metatheorems`
+- {doc}`2_hypostructure/07_factories/02_instantiation`
 
 **Part VIII: Upgrade Theorems**
-- {doc}`source/2_hypostructure/08_upgrades/01_instantaneous`
-- {doc}`source/2_hypostructure/08_upgrades/02_retroactive`
-- {doc}`source/2_hypostructure/08_upgrades/03_stability`
+- {doc}`2_hypostructure/08_upgrades/01_instantaneous`
+- {doc}`2_hypostructure/08_upgrades/02_retroactive`
+- {doc}`2_hypostructure/08_upgrades/03_stability`
 
 **Part IX: Mathematical Foundations**
-- {doc}`source/2_hypostructure/09_mathematical/01_theorems`
-- {doc}`source/2_hypostructure/09_mathematical/02_algebraic`
-- {doc}`source/2_hypostructure/09_mathematical/03_cross_reference`
-- {doc}`source/2_hypostructure/09_mathematical/04_taxonomy`
+- {doc}`2_hypostructure/09_mathematical/01_theorems`
+- {doc}`2_hypostructure/09_mathematical/02_algebraic`
+- {doc}`2_hypostructure/09_mathematical/03_cross_reference`
+- {doc}`2_hypostructure/09_mathematical/04_taxonomy`
 
 **Part XIX: Algorithmic Completeness**
-- {doc}`source/2_hypostructure/09_mathematical/05_algorithmic`
+- {doc}`2_hypostructure/09_mathematical/05_algorithmic`
 
 **Part XX: P/NP Bridge to Classical Complexity**
-- {doc}`source/2_hypostructure/09_mathematical/06_complexity_bridge`
+- {doc}`2_hypostructure/09_mathematical/06_complexity_bridge`
 
 **Part X: Meta-Learning**
-- {doc}`source/2_hypostructure/10_metalearning/01_metalearning`
+- {doc}`2_hypostructure/10_metalearning/01_metalearning`
 
 **Fractal Gas (Supplementary)**
-- {doc}`source/3_fractal_gas/03_fractal_gas_latent`
+- {doc}`3_fractal_gas/03_fractal_gas_latent`
 
 **Part XI: Appendices**
-- {doc}`source/2_hypostructure/11_appendices/01_zfc`
-- {doc}`source/2_hypostructure/11_appendices/02_notation`
+- {doc}`2_hypostructure/11_appendices/01_zfc`
+- {doc}`2_hypostructure/11_appendices/02_notation`
 
 (sec-hypo-positioning)=
 ## Positioning: Connections to Prior Work, Differences, and Advantages
@@ -249,15 +249,15 @@ This formalism is a **categorical foundation for runtime safety verification**. 
 
 6. **Classical recovery.** When the ambient topos is $\mathbf{Set}$, the categorical machinery reduces to classical PDE analysis. The framework organizes classical results rather than replacing them ({prf:ref}`rem-classical-recovery`).
 
-7. **Instantaneous upgrade metatheorems.** "Blocked" barriers and failed checks can be promoted to full YES permits under structural conditions—infinite energy under drift becomes finite energy under renormalized measure, zero Hessian eigenvalue with spectral gap gives exponential convergence, no concentration with finite Morawetz implies scattering. These upgrades allow recovery of Lyapunov functions and promote Thin interfaces to full objects ({doc}`source/2_hypostructure/08_upgrades/01_instantaneous`).
+7. **Instantaneous upgrade metatheorems.** "Blocked" barriers and failed checks can be promoted to full YES permits under structural conditions—infinite energy under drift becomes finite energy under renormalized measure, zero Hessian eigenvalue with spectral gap gives exponential convergence, no concentration with finite Morawetz implies scattering. These upgrades allow recovery of Lyapunov functions and promote Thin interfaces to full objects ({doc}`2_hypostructure/08_upgrades/01_instantaneous`).
 
-8. **Algorithmic completeness.** The five algorithm classes (Climbers, Propagators, Alchemists, Dividers, Interference Engines) are proven exhaustive via cohesive topos theory—polynomial-time computation requires exploiting at least one of five fundamental modalities. Blocking all five establishes information-theoretic hardness ({doc}`source/2_hypostructure/09_mathematical/05_algorithmic`).
+8. **Algorithmic completeness.** The five algorithm classes (Climbers, Propagators, Alchemists, Dividers, Interference Engines) are proven exhaustive via cohesive topos theory—polynomial-time computation requires exploiting at least one of five fundamental modalities. Blocking all five establishes information-theoretic hardness ({doc}`2_hypostructure/09_mathematical/05_algorithmic`).
 
-9. **P/NP bridge to classical complexity.** Bidirectional bridge theorems establish $P_{\text{Fragile}} = P_{\text{DTM}}$ and $NP_{\text{Fragile}} = NP_{\text{DTM}}$, allowing internal separations to export to classical complexity theory ({doc}`source/2_hypostructure/09_mathematical/06_complexity_bridge`).
+9. **P/NP bridge to classical complexity.** Bidirectional bridge theorems establish $P_{\text{Fragile}} = P_{\text{DTM}}$ and $NP_{\text{Fragile}} = NP_{\text{DTM}}$, allowing internal separations to export to classical complexity theory ({doc}`2_hypostructure/09_mathematical/06_complexity_bridge`).
 
-10. **Meta-learning extension.** The axioms themselves can be learned as solutions to constrained optimization over defect functionals, enabling automatic discovery of regularity conditions ({doc}`source/2_hypostructure/10_metalearning/01_metalearning`).
+10. **Meta-learning extension.** The axioms themselves can be learned as solutions to constrained optimization over defect functionals, enabling automatic discovery of regularity conditions ({doc}`2_hypostructure/10_metalearning/01_metalearning`).
 
-11. **ZFC grounding.** Complete translation to set-theoretic foundations is provided for readers who prefer classical mathematics ({doc}`source/2_hypostructure/11_appendices/01_zfc`).
+11. **ZFC grounding.** Complete translation to set-theoretic foundations is provided for readers who prefer classical mathematics ({doc}`2_hypostructure/11_appendices/01_zfc`).
 
 (sec-hypo-what-is-novel)=
 ### What Is Novel Here vs What Is Repackaging
@@ -273,18 +273,18 @@ This formalism is a **categorical foundation for runtime safety verification**. 
 *Proof Architecture:*
 5. **Certificate-typed execution.** Formal specification of YES/NO/INC certificates with witness types and verification functions ({prf:ref}`def-gate-permits`).
 6. **Factory Metatheorems.** Natural transformation soundness for correct-by-construction code generation ({prf:ref}`mt-fact-gate`, {prf:ref}`mt-fact-barrier`, {prf:ref}`mt-fact-surgery`).
-7. **Instantaneous Upgrade Metatheorems.** Systematic promotion of "Blocked" barrier certificates and "Surgery" re-entry certificates to full YES permits—allows recovery of Lyapunov functions under drift conditions, promotes zero eigenvalue + spectral gap to exponential convergence, upgrades no concentration + finite Morawetz to scattering. These validate Thin interfaces and promote them to full objects ({doc}`source/2_hypostructure/08_upgrades/01_instantaneous`).
+7. **Instantaneous Upgrade Metatheorems.** Systematic promotion of "Blocked" barrier certificates and "Surgery" re-entry certificates to full YES permits—allows recovery of Lyapunov functions under drift conditions, promotes zero eigenvalue + spectral gap to exponential convergence, upgrades no concentration + finite Morawetz to scattering. These validate Thin interfaces and promote them to full objects ({doc}`2_hypostructure/08_upgrades/01_instantaneous`).
 
 *Operational Specifications:*
-8. **17 Gate Nodes.** Complete formal specifications for all diagnostic checks with decidability analysis ({doc}`source/2_hypostructure/04_nodes/01_gate_nodes`).
-9. **Barrier/Surgery Architecture.** Fallback defense layer and repair mechanisms with re-entry protocols ({doc}`source/2_hypostructure/04_nodes/02_barrier_nodes`, {doc}`source/2_hypostructure/04_nodes/03_surgery_nodes`).
-10. **Exclusion Tactics E1-E12.** Obstruction-theoretic methods for proving non-existence of bad morphisms ({doc}`source/2_hypostructure/06_modules/03_lock`).
+8. **17 Gate Nodes.** Complete formal specifications for all diagnostic checks with decidability analysis ({doc}`2_hypostructure/04_nodes/01_gate_nodes`).
+9. **Barrier/Surgery Architecture.** Fallback defense layer and repair mechanisms with re-entry protocols ({doc}`2_hypostructure/04_nodes/02_barrier_nodes`, {doc}`2_hypostructure/04_nodes/03_surgery_nodes`).
+10. **Exclusion Tactics E1-E12.** Obstruction-theoretic methods for proving non-existence of bad morphisms ({doc}`2_hypostructure/06_modules/03_lock`).
 
 *Meta-Theoretic:*
-11. **Algorithmic Completeness Theory.** The five algorithm classes (Climbers, Propagators, Alchemists, Dividers, Interference Engines) are proven exhaustive via Schreiber's structure theorem—polynomial-time algorithms must factor through cohesive modalities $\{\sharp, \int, \flat, \ast, \partial\}$. Tactic E13 (Algorithmic Completeness Lock) establishes hardness by blocking all five modalities ({doc}`source/2_hypostructure/09_mathematical/05_algorithmic`).
-12. **P/NP Bridge to Classical Complexity.** Bidirectional bridge theorems establish $P_{\text{Fragile}} = P_{\text{DTM}}$ and $NP_{\text{Fragile}} = NP_{\text{DTM}}$ via adequacy of the Fragile runtime. Internal complexity separations export to classical ZFC statements about P and NP ({doc}`source/2_hypostructure/09_mathematical/06_complexity_bridge`).
-13. **Meta-Learning Axioms.** Learning hypostructure constraints as optimization over defect functionals ({doc}`source/2_hypostructure/10_metalearning/01_metalearning`).
-14. **Fractal Gas Model.** Scale-free dynamics for axiom discovery ({doc}`source/3_fractal_gas/03_fractal_gas_latent`).
+11. **Algorithmic Completeness Theory.** The five algorithm classes (Climbers, Propagators, Alchemists, Dividers, Interference Engines) are proven exhaustive via Schreiber's structure theorem—polynomial-time algorithms must factor through cohesive modalities $\{\sharp, \int, \flat, \ast, \partial\}$. Tactic E13 (Algorithmic Completeness Lock) establishes hardness by blocking all five modalities ({doc}`2_hypostructure/09_mathematical/05_algorithmic`).
+12. **P/NP Bridge to Classical Complexity.** Bidirectional bridge theorems establish $P_{\text{Fragile}} = P_{\text{DTM}}$ and $NP_{\text{Fragile}} = NP_{\text{DTM}}$ via adequacy of the Fragile runtime. Internal complexity separations export to classical ZFC statements about P and NP ({doc}`2_hypostructure/09_mathematical/06_complexity_bridge`).
+13. **Meta-Learning Axioms.** Learning hypostructure constraints as optimization over defect functionals ({doc}`2_hypostructure/10_metalearning/01_metalearning`).
+14. **Fractal Gas Model.** Scale-free dynamics for axiom discovery ({doc}`3_fractal_gas/03_fractal_gas_latent`).
 
 **Repackaging (directly inherited ingredients):**
 
@@ -317,14 +317,14 @@ This formalism is a **categorical foundation for runtime safety verification**. 
 | Area                           | Typical baseline                              | Hypostructure difference                                                                                                                                       |
 |--------------------------------|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Type systems**               | Ensure well-formedness at compile time        | Certificate-typed execution with runtime audit trail ({prf:ref}`def-certificate`)                                                                            |
-| **Runtime monitors**           | Assert statements, exception handlers         | Gate/barrier/surgery trichotomy with formal specifications ({doc}`source/2_hypostructure/04_nodes/01_gate_nodes`)                                             |
+| **Runtime monitors**           | Assert statements, exception handlers         | Gate/barrier/surgery trichotomy with formal specifications ({doc}`2_hypostructure/04_nodes/01_gate_nodes`)                                             |
 | **Proof obligations**          | Manual verification with proof assistants     | Factory metatheorems generate correct-by-construction verifiers ({prf:ref}`mt-fact-gate`)                                                                     |
 | **Error handling**             | Exception propagation, error codes            | Typed NO certificates with witness/inconclusive distinction ({prf:ref}`def-typed-no-certificates`)                                                           |
 | **Regularity proofs**          | Case-by-case PDE analysis                     | Systematic sieve traversal with certificate accumulation ({prf:ref}`def-sieve-epoch`)                                                                        |
-| **Undecidable predicates**     | Conservative approximation or timeout         | Tactic library E1-E12 with $K^{\text{inc}}$ fallback ({doc}`source/2_hypostructure/06_modules/03_lock`)                                                        |
-| **Surgery/repair**             | Ad hoc modifications                          | Certified surgery nodes with re-entry protocols ({doc}`source/2_hypostructure/04_nodes/03_surgery_nodes`)                                                      |
-| **Axiom discovery**            | Human insight, conjecture-and-test            | Meta-learning optimization over defect functionals ({doc}`source/2_hypostructure/10_metalearning/01_metalearning`)                                             |
-| **Classical grounding**        | Implicit set-theoretic interpretation         | Explicit ZFC translation with full correspondence ({doc}`source/2_hypostructure/11_appendices/01_zfc`)                                                         |
+| **Undecidable predicates**     | Conservative approximation or timeout         | Tactic library E1-E12 with $K^{\text{inc}}$ fallback ({doc}`2_hypostructure/06_modules/03_lock`)                                                        |
+| **Surgery/repair**             | Ad hoc modifications                          | Certified surgery nodes with re-entry protocols ({doc}`2_hypostructure/04_nodes/03_surgery_nodes`)                                                      |
+| **Axiom discovery**            | Human insight, conjecture-and-test            | Meta-learning optimization over defect functionals ({doc}`2_hypostructure/10_metalearning/01_metalearning`)                                             |
+| **Classical grounding**        | Implicit set-theoretic interpretation         | Explicit ZFC translation with full correspondence ({doc}`2_hypostructure/11_appendices/01_zfc`)                                                         |
 
 (sec-hypo-axioms-overview)=
 ## The Five Axioms
@@ -478,10 +478,10 @@ This framework makes strong claims about categorical structure and proof-carryin
 
 1. **Why infinity-topoi?** The cohesive structure handles gauge redundancy and homotopy that set theory loses. See {prf:ref}`def-ambient-topos` and {prf:ref}`rem-classical-recovery`.
 
-2. **What about undecidability?** Gate 17 (the Lock) handles undecidable predicates via the tactic library E1-E12. The system is sound regardless—$K^{\text{inc}}$ routes to fallback. See {doc}`source/2_hypostructure/06_modules/03_lock`.
+2. **What about undecidability?** Gate 17 (the Lock) handles undecidable predicates via the tactic library E1-E12. The system is sound regardless—$K^{\text{inc}}$ routes to fallback. See {doc}`2_hypostructure/06_modules/03_lock`.
 
 3. **Is factory code generation practical?** The Factory Metatheorems specify *interface contracts*, not universal decision procedures. Domain-specific verifiers are provided by users; the framework guarantees soundness. See {prf:ref}`mt-fact-gate`.
 
-4. **How does this relate to proof assistants?** The certificate system is analogous to proof terms in Coq/Lean. The difference is operational focus—we verify dynamical properties, not static types. See {doc}`source/2_hypostructure/03_sieve/02_kernel`.
+4. **How does this relate to proof assistants?** The certificate system is analogous to proof terms in Coq/Lean. The difference is operational focus—we verify dynamical properties, not static types. See {doc}`2_hypostructure/03_sieve/02_kernel`.
 
-5. **What if the axioms are incomplete?** The Meta-Learning extension addresses this—axioms can be learned as optimization over defect functionals. See {doc}`source/2_hypostructure/10_metalearning/01_metalearning`.
+5. **What if the axioms are incomplete?** The Meta-Learning extension addresses this—axioms can be learned as optimization over defect functionals. See {doc}`2_hypostructure/10_metalearning/01_metalearning`.

--- a/docs/source/3_fractal_gas/03_fractal_gas_latent.md
+++ b/docs/source/3_fractal_gas/03_fractal_gas_latent.md
@@ -583,8 +583,6 @@ The Latent Fractal Gas is treated as an **open system**: the domain boundary ind
 
 ### 0.3 The Lock (Node 17)
 
----
-
 ## Part I: The Instantiation (Thin Object Definitions)
 
 ### 1. The Arena ($\mathcal{X}^{\text{thin}}$)
@@ -619,8 +617,6 @@ The Latent Fractal Gas is treated as an **open system**: the domain boundary ind
 ### Execution Protocol
 
 We run the full sieve using the instantiation assumptions A1-A6. The algorithmic factories (RESOLVE-AutoAdmit/AutoProfile) certify permits that reduce to compactness, analyticity, and finite precision. Each node below records an explicit witness.
-
----
 
 ### Level 1: Conservation
 
@@ -659,8 +655,6 @@ which is compact because $B$ is compact and we restrict to a compact velocity co
 **Certificate:**
 $$K_{C_\mu}^+ = (S_N, \Omega_{\mathrm{alive}}//S_N, \text{compactness witness}).$$
 
----
-
 ### Level 2: Duality & Symmetry
 
 #### Node 4: ScaleCheck ($\mathrm{SC}_\lambda$)
@@ -686,8 +680,6 @@ $$K_{\mathrm{TypeII}}^{\mathrm{blk}} = (\text{BarrierTypeII}, \text{compact aren
 **Certificate:**
 $$K_{\mathrm{SC}_{\partial c}}^+ = (\Theta, \theta_0, C=0).$$
 
----
-
 ### Level 3: Geometry & Stiffness
 
 #### Node 6: GeomCheck ($\mathrm{Cap}_H$)
@@ -710,8 +702,6 @@ $$K_{\mathrm{Cap}_H}^+ = (\Sigma=\{\text{NaN/Inf},\ \text{cemetery}\},\ \text{Ca
 **Certificate:**
 $$K_{\mathrm{LS}_\sigma}^+ = (\|\nabla\Phi_{\text{eff}}\|_G,\ \|\nabla G\|,\ \|\nabla\mathcal{R}\|\ \text{bounded on}\ B).$$
 
----
-
 ### Level 4: Topology
 
 #### Node 8: TopoCheck ($\mathrm{TB}_\pi$)
@@ -733,8 +723,6 @@ $$K_{\mathrm{TB}_\pi}^+ = (\tau \equiv \text{const}, \pi_0(\mathcal{X})=\{\ast\}
 
 **Certificate:**
 $$K_{\mathrm{TB}_O}^+ = (\mathbb{R}_{\mathrm{an},\exp},\ \Sigma\ \text{definable},\ \text{finite stratification}).$$
-
----
 
 ### Level 5: Mixing
 
@@ -768,11 +756,9 @@ m_\epsilon>0,\ (c_{\min},c_{\max})\ \text{certified},\ \exists\,C\Subset \Omega_
 \right).
 $$
 
----
+## Level 6: Complexity
 
-### Level 6: Complexity
-
-#### Node 11: ComplexCheck ($\mathrm{Rep}_K$)
+### Node 11: ComplexCheck ($\mathrm{Rep}_K$)
 
 **Question:** Does the system admit a finite description?
 
@@ -783,7 +769,7 @@ $$K_{\mathrm{Rep}_K}^+ = (\mathcal{L}_{\mathrm{fp}}, D_{\mathrm{fp}}, K(z) \le C
 
 ---
 
-#### Node 12: OscillateCheck ($\mathrm{GC}_\nabla$)
+### Node 12: OscillateCheck ($\mathrm{GC}_\nabla$)
 
 **Question:** Does the flow oscillate (NOT a gradient flow)?
 
@@ -795,11 +781,9 @@ $$K_{\mathrm{Rep}_K}^+ = (\mathcal{L}_{\mathrm{fp}}, D_{\mathrm{fp}}, K(z) \le C
 $$K_{\mathrm{GC}_\nabla}^+ = (\text{non-gradient stochastic flow}),$$
 $$K_{\mathrm{Freq}}^{\mathrm{blk}} = (\text{BarrierFreq}, \text{oscillation bounded on the alive core}, \{V_{\mathrm{core}}\}).$$
 
----
+## Level 7: Boundary (Open Systems)
 
-### Level 7: Boundary (Open Systems)
-
-#### Node 13: BoundaryCheck ($\mathrm{Bound}_\partial$)
+### Node 13: BoundaryCheck ($\mathrm{Bound}_\partial$)
 
 **Question:** Is the system open (has boundary interactions)?
 
@@ -813,7 +797,7 @@ $$K_{\mathrm{Bound}_\partial}^+ = (\partial\Omega=\mathcal{Z}\setminus B,\ \iota
 
 ---
 
-#### Node 14: OverloadCheck ($\mathrm{Bound}_B$)
+### Node 14: OverloadCheck ($\mathrm{Bound}_B$)
 
 **Question:** Is the input bounded (no injection overload)?
 
@@ -829,7 +813,7 @@ $$K_{\mathrm{Bode}}^{\mathrm{blk}} = (\text{thermostat + killing/recovery preven
 
 ---
 
-#### Node 15: StarveCheck ($\mathrm{Bound}_{\Sigma}$)
+### Node 15: StarveCheck ($\mathrm{Bound}_{\Sigma}$)
 
 **Question:** Is the input sufficient (no resource starvation)?
 
@@ -840,7 +824,7 @@ $$K_{\mathrm{Bound}_{\Sigma}}^{\mathrm{blk}} = (\text{QSD/conditioned dynamics e
 
 ---
 
-#### Node 16: AlignCheck ($\mathrm{GC}_T$)
+### Node 16: AlignCheck ($\mathrm{GC}_T$)
 
 **Question:** Is control matched to disturbance (requisite variety)?
 
@@ -853,11 +837,9 @@ equivalently $\mathbb{E}[\Phi^{\mathrm{sel}}-\Phi\mid V,c]\le 0$ for $\Phi:=V_{\
 **Certificate:**
 $$K_{\mathrm{GC}_T}^+ = (\mathbb{E}[\Phi^{\mathrm{sel}}-\Phi\mid V,c]\le 0\ \text{(selection-stage)},\ \text{fitness-aligned resampling}).$$
 
----
+## Level 8: The Lock
 
-### Level 8: The Lock
-
-#### Node 17: BarrierExclusion ($\mathrm{Cat}_{\mathrm{Hom}}$)
+### Node 17: BarrierExclusion ($\mathrm{Cat}_{\mathrm{Hom}}$)
 
 **Question:** Is $\mathrm{Hom}(\mathcal{H}_{\mathrm{bad}}, \mathcal{H}) = \emptyset$?
 


### PR DESCRIPTION
- Fix malformed citation targets: change semicolons to commas in {cite} directives
  - Bennett88; LloydPagels88 → Bennett88,LloydPagels88
  - Levin73b; Schnorr73 → Levin73b,Schnorr73 (2 instances)
- Remove trailing transition (---) at end of 03_contracts.md

These changes fix the build-blocking ValueError and ERROR that prevented
jupyter-book from building the documentation successfully.