### PR TITLE
Fix hyperlinks and add explicit output factory sections

### DIFF
--- a/docs/source/2_hypostructure/intro_hypostructure.md
+++ b/docs/source/2_hypostructure/intro_hypostructure.md
@@ -72,7 +72,14 @@ The **Algorithmic Representation Theorem (MT-AlgComplete)** proves these five cl
 Bidirectional bridge theorems establish $P_{\text{Fragile}} = P_{\text{DTM}}$ and $NP_{\text{Fragile}} = NP_{\text{DTM}}$, allowing internal complexity separations to export to classical ZFC statements about P and NP. The framework reduces the P vs NP question to concrete geometric/topological properties of energy landscapes.
 
 **Meta-Learning Extension:**
-The axioms themselves can be *learned* as the solution to a constrained optimization problem over defect functionals. See {doc}`2_hypostructure/10_metalearning/01_metalearning`.
+The axioms themselves can be *learned* as the solution to a constrained optimization problem over defect functionals. See [Meta-Learning](10_metalearning/01_metalearning.md).
+
+**Output Factories:**
+The Factory Metatheorems generate not only verifiers but also critical mathematical objects:
+- **Lyapunov Function Factory:** Generates energy-like functionals from structural data. When gate checks validate dissipation and stiffness conditions, the factory automatically constructs a Lyapunov function with certified convergence properties.
+- **LSI (Łojasiewicz-Simon Inequality) Factory:** Produces gradient inequality certificates from spectral gap data. When Gate 7 confirms stiffness and upgrade theorems validate the spectral gap, the factory generates an LSI with explicit exponent bounds, enabling exponential convergence analysis.
+
+These factories transform Thin interface validations into Full mathematical objects with computational guarantees.
 
 **Why "Hypostructure"?**
 A hypostructure is an object carrying *surgery-resolution data*—the information needed to repair singularities if they occur. The term emphasizes that we are not just detecting problems but providing certified repair mechanisms.
@@ -106,17 +113,17 @@ A hypostructure is an object carrying *surgery-resolution data*—the informatio
 - Cobordism theory for surgery operations
 
 **Quick Navigation:**
-- *Want the categorical foundations?* → {doc}`2_hypostructure/01_foundations/01_categorical`
-- *Want the axiom system?* → {doc}`2_hypostructure/02_axioms/01_axiom_system`
-- *Want the kernel and certificates?* → {doc}`2_hypostructure/03_sieve/02_kernel`
-- *Want gate node specifications?* → {doc}`2_hypostructure/04_nodes/01_gate_nodes`
-- *Want factory metatheorems?* → {doc}`2_hypostructure/07_factories/01_metatheorems`
-- *Want upgrade theorems?* → {doc}`2_hypostructure/08_upgrades/01_instantaneous`
-- *Want mathematical foundations?* → {doc}`2_hypostructure/09_mathematical/01_theorems`
-- *Want algorithmic completeness theory?* → {doc}`2_hypostructure/09_mathematical/05_algorithmic`
-- *Want P/NP complexity bridge?* → {doc}`2_hypostructure/09_mathematical/06_complexity_bridge`
-- *Want meta-learning?* → {doc}`2_hypostructure/10_metalearning/01_metalearning`
-- *Want ZFC translation?* → {doc}`2_hypostructure/11_appendices/01_zfc`
+- *Want the categorical foundations?* → [Categorical Foundations](01_foundations/01_categorical.md)
+- *Want the axiom system?* → [Axiom System](02_axioms/01_axiom_system.md)
+- *Want the kernel and certificates?* → [Sieve Kernel](03_sieve/02_kernel.md)
+- *Want gate node specifications?* → [Gate Nodes](04_nodes/01_gate_nodes.md)
+- *Want factory metatheorems?* → [Factory Metatheorems](07_factories/01_metatheorems.md)
+- *Want upgrade theorems?* → [Upgrade Theorems](08_upgrades/01_instantaneous.md)
+- *Want mathematical foundations?* → [Mathematical Foundations](09_mathematical/01_theorems.md)
+- *Want algorithmic completeness theory?* → [Algorithmic Completeness](09_mathematical/05_algorithmic.md)
+- *Want P/NP complexity bridge?* → [P/NP Bridge](09_mathematical/06_complexity_bridge.md)
+- *Want meta-learning?* → [Meta-Learning](10_metalearning/01_metalearning.md)
+- *Want ZFC translation?* → [ZFC Translation](11_appendices/01_zfc.md)
 :::
 
 (sec-hypo-how-to-read)=
@@ -143,15 +150,15 @@ This formalism is designed to be **modular**. Each part is written to be as self
 
 | If you want...                    | Read...                                  | Dependencies                          |
 |-----------------------------------|------------------------------------------|---------------------------------------|
-| Categorical foundations only      | {doc}`Part I <2_hypostructure/01_foundations/01_categorical>` | Basic category theory                 |
-| The axiom system                  | {doc}`Part II <2_hypostructure/02_axioms/01_axiom_system>` | Part I helpful but not required       |
-| Gate/barrier/surgery specs        | {doc}`Part IV <2_hypostructure/04_nodes/01_gate_nodes>`, {doc}`Part V <2_hypostructure/05_interfaces/01_gate_evaluator>` | Part III for certificate semantics    |
-| Factory metatheorems              | {doc}`Part VII <2_hypostructure/07_factories/01_metatheorems>` | Parts III-V for context               |
-| Upgrade theorems (Thin → Full)    | {doc}`Part VIII <2_hypostructure/08_upgrades/01_instantaneous>` | Parts III-IV for certificate types    |
-| Algorithmic completeness          | {doc}`Part XIX <2_hypostructure/09_mathematical/05_algorithmic>` | Part I for modalities                 |
-| P/NP complexity bridge            | {doc}`Part XX <2_hypostructure/09_mathematical/06_complexity_bridge>` | Part XIX for algorithm classes        |
-| Meta-learning axioms              | {doc}`Part X <2_hypostructure/10_metalearning/01_metalearning>` | Can standalone with Part II summary   |
-| ZFC translation                   | {doc}`Part XI <2_hypostructure/11_appendices/01_zfc>` | Can standalone                        |
+| Categorical foundations only      | [Part I: Categorical Foundations](01_foundations/01_categorical.md) | Basic category theory                 |
+| The axiom system                  | [Part II: Axiom System](02_axioms/01_axiom_system.md) | Part I helpful but not required       |
+| Gate/barrier/surgery specs        | [Part IV: Gate Nodes](04_nodes/01_gate_nodes.md), [Part V: Gate Evaluator](05_interfaces/01_gate_evaluator.md) | Part III for certificate semantics    |
+| Factory metatheorems              | [Part VII: Factory Metatheorems](07_factories/01_metatheorems.md) | Parts III-V for context               |
+| Upgrade theorems (Thin → Full)    | [Part VIII: Upgrade Theorems](08_upgrades/01_instantaneous.md) | Parts III-IV for certificate types    |
+| Algorithmic completeness          | [Part XIX: Algorithmic Completeness](09_mathematical/05_algorithmic.md) | Part I for modalities                 |
+| P/NP complexity bridge            | [Part XX: P/NP Bridge](09_mathematical/06_complexity_bridge.md) | Part XIX for algorithm classes        |
+| Meta-learning axioms              | [Part X: Meta-Learning](10_metalearning/01_metalearning.md) | Can standalone with Part II summary   |
+| ZFC translation                   | [Part XI: ZFC Translation](11_appendices/01_zfc.md) | Can standalone                        |
 
 ### LLM-Assisted Exploration
 
@@ -173,61 +180,61 @@ A recommended approach for understanding this framework:
 ## Book Map
 
 **Part I: Categorical Foundations**
-- {doc}`2_hypostructure/01_foundations/01_categorical`
-- {doc}`2_hypostructure/01_foundations/02_constructive`
+- [Categorical Foundations](01_foundations/01_categorical.md)
+- [Constructive Mathematics](01_foundations/02_constructive.md)
 
 **Part II: Axiom System**
-- {doc}`2_hypostructure/02_axioms/01_axiom_system`
+- [Axiom System](02_axioms/01_axiom_system.md)
 
 **Part III: The Sieve**
-- {doc}`2_hypostructure/03_sieve/01_structural`
-- {doc}`2_hypostructure/03_sieve/02_kernel`
+- [Structural Framework](03_sieve/01_structural.md)
+- [Sieve Kernel](03_sieve/02_kernel.md)
 
 **Part IV: Node Specifications**
-- {doc}`2_hypostructure/04_nodes/01_gate_nodes`
-- {doc}`2_hypostructure/04_nodes/02_barrier_nodes`
-- {doc}`2_hypostructure/04_nodes/03_surgery_nodes`
+- [Gate Nodes](04_nodes/01_gate_nodes.md)
+- [Barrier Nodes](04_nodes/02_barrier_nodes.md)
+- [Surgery Nodes](04_nodes/03_surgery_nodes.md)
 
 **Part V: Soft Interfaces**
-- {doc}`2_hypostructure/05_interfaces/01_gate_evaluator`
-- {doc}`2_hypostructure/05_interfaces/02_permits`
-- {doc}`2_hypostructure/05_interfaces/03_contracts`
+- [Gate Evaluator](05_interfaces/01_gate_evaluator.md)
+- [Permits](05_interfaces/02_permits.md)
+- [Contracts](05_interfaces/03_contracts.md)
 
 **Part VI: Singularity Modules**
-- {doc}`2_hypostructure/06_modules/01_singularity`
-- {doc}`2_hypostructure/06_modules/02_equivalence`
-- {doc}`2_hypostructure/06_modules/03_lock`
+- [Singularity Detection](06_modules/01_singularity.md)
+- [Equivalence Relations](06_modules/02_equivalence.md)
+- [Lock Mechanism](06_modules/03_lock.md)
 
 **Part VII: Factory Metatheorems**
-- {doc}`2_hypostructure/07_factories/01_metatheorems`
-- {doc}`2_hypostructure/07_factories/02_instantiation`
+- [Factory Metatheorems](07_factories/01_metatheorems.md)
+- [Factory Instantiation](07_factories/02_instantiation.md)
 
 **Part VIII: Upgrade Theorems**
-- {doc}`2_hypostructure/08_upgrades/01_instantaneous`
-- {doc}`2_hypostructure/08_upgrades/02_retroactive`
-- {doc}`2_hypostructure/08_upgrades/03_stability`
+- [Instantaneous Upgrades](08_upgrades/01_instantaneous.md)
+- [Retroactive Upgrades](08_upgrades/02_retroactive.md)
+- [Stability Analysis](08_upgrades/03_stability.md)
 
 **Part IX: Mathematical Foundations**
-- {doc}`2_hypostructure/09_mathematical/01_theorems`
-- {doc}`2_hypostructure/09_mathematical/02_algebraic`
-- {doc}`2_hypostructure/09_mathematical/03_cross_reference`
-- {doc}`2_hypostructure/09_mathematical/04_taxonomy`
+- [Core Theorems](09_mathematical/01_theorems.md)
+- [Algebraic Structure](09_mathematical/02_algebraic.md)
+- [Cross-References](09_mathematical/03_cross_reference.md)
+- [Taxonomy](09_mathematical/04_taxonomy.md)
 
 **Part XIX: Algorithmic Completeness**
-- {doc}`2_hypostructure/09_mathematical/05_algorithmic`
+- [Algorithmic Completeness Theory](09_mathematical/05_algorithmic.md)
 
 **Part XX: P/NP Bridge to Classical Complexity**
-- {doc}`2_hypostructure/09_mathematical/06_complexity_bridge`
+- [P/NP Complexity Bridge](09_mathematical/06_complexity_bridge.md)
 
 **Part X: Meta-Learning**
-- {doc}`2_hypostructure/10_metalearning/01_metalearning`
+- [Meta-Learning Framework](10_metalearning/01_metalearning.md)
 
 **Fractal Gas (Supplementary)**
-- {doc}`3_fractal_gas/03_fractal_gas_latent`
+- [Fractal Gas Model](../3_fractal_gas/03_fractal_gas_latent.md)
 
 **Part XI: Appendices**
-- {doc}`2_hypostructure/11_appendices/01_zfc`
-- {doc}`2_hypostructure/11_appendices/02_notation`
+- [ZFC Translation](11_appendices/01_zfc.md)
+- [Notation Guide](11_appendices/02_notation.md)
 
 (sec-hypo-positioning)=
 ## Positioning: Connections to Prior Work, Differences, and Advantages
@@ -249,15 +256,15 @@ This formalism is a **categorical foundation for runtime safety verification**. 
 
 6. **Classical recovery.** When the ambient topos is $\mathbf{Set}$, the categorical machinery reduces to classical PDE analysis. The framework organizes classical results rather than replacing them ({prf:ref}`rem-classical-recovery`).
 
-7. **Instantaneous upgrade metatheorems.** "Blocked" barriers and failed checks can be promoted to full YES permits under structural conditions—infinite energy under drift becomes finite energy under renormalized measure, zero Hessian eigenvalue with spectral gap gives exponential convergence, no concentration with finite Morawetz implies scattering. These upgrades allow recovery of Lyapunov functions and promote Thin interfaces to full objects ({doc}`2_hypostructure/08_upgrades/01_instantaneous`).
+7. **Instantaneous upgrade metatheorems.** "Blocked" barriers and failed checks can be promoted to full YES permits under structural conditions—infinite energy under drift becomes finite energy under renormalized measure, zero Hessian eigenvalue with spectral gap gives exponential convergence, no concentration with finite Morawetz implies scattering. These upgrades allow recovery of Lyapunov functions and promote Thin interfaces to full objects ([Instantaneous Upgrades](08_upgrades/01_instantaneous.md)).
 
-8. **Algorithmic completeness.** The five algorithm classes (Climbers, Propagators, Alchemists, Dividers, Interference Engines) are proven exhaustive via cohesive topos theory—polynomial-time computation requires exploiting at least one of five fundamental modalities. Blocking all five establishes information-theoretic hardness ({doc}`2_hypostructure/09_mathematical/05_algorithmic`).
+8. **Algorithmic completeness.** The five algorithm classes (Climbers, Propagators, Alchemists, Dividers, Interference Engines) are proven exhaustive via cohesive topos theory—polynomial-time computation requires exploiting at least one of five fundamental modalities. Blocking all five establishes information-theoretic hardness ([Algorithmic Completeness](09_mathematical/05_algorithmic.md)).
 
-9. **P/NP bridge to classical complexity.** Bidirectional bridge theorems establish $P_{\text{Fragile}} = P_{\text{DTM}}$ and $NP_{\text{Fragile}} = NP_{\text{DTM}}$, allowing internal separations to export to classical complexity theory ({doc}`2_hypostructure/09_mathematical/06_complexity_bridge`).
+9. **P/NP bridge to classical complexity.** Bidirectional bridge theorems establish $P_{\text{Fragile}} = P_{\text{DTM}}$ and $NP_{\text{Fragile}} = NP_{\text{DTM}}$, allowing internal separations to export to classical complexity theory ([P/NP Bridge](09_mathematical/06_complexity_bridge.md)).
 
-10. **Meta-learning extension.** The axioms themselves can be learned as solutions to constrained optimization over defect functionals, enabling automatic discovery of regularity conditions ({doc}`2_hypostructure/10_metalearning/01_metalearning`).
+10. **Meta-learning extension.** The axioms themselves can be learned as solutions to constrained optimization over defect functionals, enabling automatic discovery of regularity conditions ([Meta-Learning](10_metalearning/01_metalearning.md)).
 
-11. **ZFC grounding.** Complete translation to set-theoretic foundations is provided for readers who prefer classical mathematics ({doc}`2_hypostructure/11_appendices/01_zfc`).
+11. **ZFC grounding.** Complete translation to set-theoretic foundations is provided for readers who prefer classical mathematics ([ZFC Translation](11_appendices/01_zfc.md)).
 
 (sec-hypo-what-is-novel)=
 ### What Is Novel Here vs What Is Repackaging
@@ -273,18 +280,18 @@ This formalism is a **categorical foundation for runtime safety verification**. 
 *Proof Architecture:*
 5. **Certificate-typed execution.** Formal specification of YES/NO/INC certificates with witness types and verification functions ({prf:ref}`def-gate-permits`).
 6. **Factory Metatheorems.** Natural transformation soundness for correct-by-construction code generation ({prf:ref}`mt-fact-gate`, {prf:ref}`mt-fact-barrier`, {prf:ref}`mt-fact-surgery`).
-7. **Instantaneous Upgrade Metatheorems.** Systematic promotion of "Blocked" barrier certificates and "Surgery" re-entry certificates to full YES permits—allows recovery of Lyapunov functions under drift conditions, promotes zero eigenvalue + spectral gap to exponential convergence, upgrades no concentration + finite Morawetz to scattering. These validate Thin interfaces and promote them to full objects ({doc}`2_hypostructure/08_upgrades/01_instantaneous`).
+7. **Instantaneous Upgrade Metatheorems.** Systematic promotion of "Blocked" barrier certificates and "Surgery" re-entry certificates to full YES permits—allows recovery of Lyapunov functions under drift conditions, promotes zero eigenvalue + spectral gap to exponential convergence, upgrades no concentration + finite Morawetz to scattering. These validate Thin interfaces and promote them to full objects ([Instantaneous Upgrades](08_upgrades/01_instantaneous.md)).
 
 *Operational Specifications:*
-8. **17 Gate Nodes.** Complete formal specifications for all diagnostic checks with decidability analysis ({doc}`2_hypostructure/04_nodes/01_gate_nodes`).
-9. **Barrier/Surgery Architecture.** Fallback defense layer and repair mechanisms with re-entry protocols ({doc}`2_hypostructure/04_nodes/02_barrier_nodes`, {doc}`2_hypostructure/04_nodes/03_surgery_nodes`).
-10. **Exclusion Tactics E1-E12.** Obstruction-theoretic methods for proving non-existence of bad morphisms ({doc}`2_hypostructure/06_modules/03_lock`).
+8. **17 Gate Nodes.** Complete formal specifications for all diagnostic checks with decidability analysis ([Gate Nodes](04_nodes/01_gate_nodes.md)).
+9. **Barrier/Surgery Architecture.** Fallback defense layer and repair mechanisms with re-entry protocols ([Barrier Nodes](04_nodes/02_barrier_nodes.md), [Surgery Nodes](04_nodes/03_surgery_nodes.md)).
+10. **Exclusion Tactics E1-E12.** Obstruction-theoretic methods for proving non-existence of bad morphisms ([Lock Mechanism](06_modules/03_lock.md)).
 
 *Meta-Theoretic:*
-11. **Algorithmic Completeness Theory.** The five algorithm classes (Climbers, Propagators, Alchemists, Dividers, Interference Engines) are proven exhaustive via Schreiber's structure theorem—polynomial-time algorithms must factor through cohesive modalities $\{\sharp, \int, \flat, \ast, \partial\}$. Tactic E13 (Algorithmic Completeness Lock) establishes hardness by blocking all five modalities ({doc}`2_hypostructure/09_mathematical/05_algorithmic`).
-12. **P/NP Bridge to Classical Complexity.** Bidirectional bridge theorems establish $P_{\text{Fragile}} = P_{\text{DTM}}$ and $NP_{\text{Fragile}} = NP_{\text{DTM}}$ via adequacy of the Fragile runtime. Internal complexity separations export to classical ZFC statements about P and NP ({doc}`2_hypostructure/09_mathematical/06_complexity_bridge`).
-13. **Meta-Learning Axioms.** Learning hypostructure constraints as optimization over defect functionals ({doc}`2_hypostructure/10_metalearning/01_metalearning`).
-14. **Fractal Gas Model.** Scale-free dynamics for axiom discovery ({doc}`3_fractal_gas/03_fractal_gas_latent`).
+11. **Algorithmic Completeness Theory.** The five algorithm classes (Climbers, Propagators, Alchemists, Dividers, Interference Engines) are proven exhaustive via Schreiber's structure theorem—polynomial-time algorithms must factor through cohesive modalities $\{\sharp, \int, \flat, \ast, \partial\}$. Tactic E13 (Algorithmic Completeness Lock) establishes hardness by blocking all five modalities ([Algorithmic Completeness](09_mathematical/05_algorithmic.md)).
+12. **P/NP Bridge to Classical Complexity.** Bidirectional bridge theorems establish $P_{\text{Fragile}} = P_{\text{DTM}}$ and $NP_{\text{Fragile}} = NP_{\text{DTM}}$ via adequacy of the Fragile runtime. Internal complexity separations export to classical ZFC statements about P and NP ([P/NP Bridge](09_mathematical/06_complexity_bridge.md)).
+13. **Meta-Learning Axioms.** Learning hypostructure constraints as optimization over defect functionals ([Meta-Learning](10_metalearning/01_metalearning.md)).
+14. **Fractal Gas Model.** Scale-free dynamics for axiom discovery ([Fractal Gas](../3_fractal_gas/03_fractal_gas_latent.md)).
 
 **Repackaging (directly inherited ingredients):**
 
@@ -317,14 +324,14 @@ This formalism is a **categorical foundation for runtime safety verification**. 
 | Area                           | Typical baseline                              | Hypostructure difference                                                                                                                                       |
 |--------------------------------|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Type systems**               | Ensure well-formedness at compile time        | Certificate-typed execution with runtime audit trail ({prf:ref}`def-certificate`)                                                                            |
-| **Runtime monitors**           | Assert statements, exception handlers         | Gate/barrier/surgery trichotomy with formal specifications ({doc}`2_hypostructure/04_nodes/01_gate_nodes`)                                             |
+| **Runtime monitors**           | Assert statements, exception handlers         | Gate/barrier/surgery trichotomy with formal specifications ([Gate Nodes](04_nodes/01_gate_nodes.md))                                             |
 | **Proof obligations**          | Manual verification with proof assistants     | Factory metatheorems generate correct-by-construction verifiers ({prf:ref}`mt-fact-gate`)                                                                     |
 | **Error handling**             | Exception propagation, error codes            | Typed NO certificates with witness/inconclusive distinction ({prf:ref}`def-typed-no-certificates`)                                                           |
 | **Regularity proofs**          | Case-by-case PDE analysis                     | Systematic sieve traversal with certificate accumulation ({prf:ref}`def-sieve-epoch`)                                                                        |
-| **Undecidable predicates**     | Conservative approximation or timeout         | Tactic library E1-E12 with $K^{\text{inc}}$ fallback ({doc}`2_hypostructure/06_modules/03_lock`)                                                        |
-| **Surgery/repair**             | Ad hoc modifications                          | Certified surgery nodes with re-entry protocols ({doc}`2_hypostructure/04_nodes/03_surgery_nodes`)                                                      |
-| **Axiom discovery**            | Human insight, conjecture-and-test            | Meta-learning optimization over defect functionals ({doc}`2_hypostructure/10_metalearning/01_metalearning`)                                             |
-| **Classical grounding**        | Implicit set-theoretic interpretation         | Explicit ZFC translation with full correspondence ({doc}`2_hypostructure/11_appendices/01_zfc`)                                                         |
+| **Undecidable predicates**     | Conservative approximation or timeout         | Tactic library E1-E12 with $K^{\text{inc}}$ fallback ([Lock Mechanism](06_modules/03_lock.md))                                                        |
+| **Surgery/repair**             | Ad hoc modifications                          | Certified surgery nodes with re-entry protocols ([Surgery Nodes](04_nodes/03_surgery_nodes.md))                                                      |
+| **Axiom discovery**            | Human insight, conjecture-and-test            | Meta-learning optimization over defect functionals ([Meta-Learning](10_metalearning/01_metalearning.md))                                             |
+| **Classical grounding**        | Implicit set-theoretic interpretation         | Explicit ZFC translation with full correspondence ([ZFC Translation](11_appendices/01_zfc.md))                                                         |
 
 (sec-hypo-axioms-overview)=
 ## The Five Axioms
@@ -478,10 +485,10 @@ This framework makes strong claims about categorical structure and proof-carryin
 
 1. **Why infinity-topoi?** The cohesive structure handles gauge redundancy and homotopy that set theory loses. See {prf:ref}`def-ambient-topos` and {prf:ref}`rem-classical-recovery`.
 
-2. **What about undecidability?** Gate 17 (the Lock) handles undecidable predicates via the tactic library E1-E12. The system is sound regardless—$K^{\text{inc}}$ routes to fallback. See {doc}`2_hypostructure/06_modules/03_lock`.
+2. **What about undecidability?** Gate 17 (the Lock) handles undecidable predicates via the tactic library E1-E12. The system is sound regardless—$K^{\text{inc}}$ routes to fallback. See [Lock Mechanism](06_modules/03_lock.md).
 
 3. **Is factory code generation practical?** The Factory Metatheorems specify *interface contracts*, not universal decision procedures. Domain-specific verifiers are provided by users; the framework guarantees soundness. See {prf:ref}`mt-fact-gate`.
 
-4. **How does this relate to proof assistants?** The certificate system is analogous to proof terms in Coq/Lean. The difference is operational focus—we verify dynamical properties, not static types. See {doc}`2_hypostructure/03_sieve/02_kernel`.
+4. **How does this relate to proof assistants?** The certificate system is analogous to proof terms in Coq/Lean. The difference is operational focus—we verify dynamical properties, not static types. See [Sieve Kernel](03_sieve/02_kernel.md).
 
-5. **What if the axioms are incomplete?** The Meta-Learning extension addresses this—axioms can be learned as optimization over defect functionals. See {doc}`2_hypostructure/10_metalearning/01_metalearning`.
+5. **What if the axioms are incomplete?** The Meta-Learning extension addresses this—axioms can be learned as optimization over defect functionals. See [Meta-Learning](10_metalearning/01_metalearning.md).


### PR DESCRIPTION
- Convert all {doc} references to proper MyST markdown hyperlinks
- Replace full document paths with descriptive link text
- Add explicit "Output Factories" section with:
  - Lyapunov Function Factory: Generates energy functionals from structural data
  - LSI Factory: Produces Łojasiewicz-Simon inequality certificates
- Update Quick Navigation section with proper hyperlinks
- Update Book Map section with descriptive link text
- Update all comparison tables and cross-references

This fixes the issue where full document names were displayed instead of clickable hyperlinks in the rendered HTML documentation.