### PR TITLE
Fix Jupyter Book build: register custom types in sphinx-proof counter map

### DIFF
--- a/docs/fragile_proof_types.py
+++ b/docs/fragile_proof_types.py
@@ -29,8 +29,13 @@ def setup(app: Sphinx):
     except Exception:
         return {"version": "builtin", "parallel_read_safe": True, "parallel_write_safe": True}
 
+    from sphinx_proof.directive import DEFAULT_REALTYP_TO_COUNTERTYP
+
     proof_nodes.NODE_TYPES.setdefault("metatheorem", metatheorem_node)
     proof_nodes.NODE_TYPES.setdefault("principle", principle_node)
+
+    DEFAULT_REALTYP_TO_COUNTERTYP.setdefault("metatheorem", "metatheorem")
+    DEFAULT_REALTYP_TO_COUNTERTYP.setdefault("principle", "principle")
 
     app.add_enumerable_node(
         metatheorem_node,


### PR DESCRIPTION
The `ElementDirective.run()` in sphinx-proof looks up directive types in
`DEFAULT_REALTYP_TO_COUNTERTYP` as a fallback. Our custom 'metatheorem'
and 'principle' types were registered in NODE_TYPES but not in this map,
causing a KeyError during the build.

https://claude.ai/code/session_012ZKYKsoTph7xyjjETbBBke